### PR TITLE
⚡ Stream head + tail of large session files instead of full history

### DIFF
--- a/server/pi-session-store.ts
+++ b/server/pi-session-store.ts
@@ -1,4 +1,5 @@
-import { readdir, readFile, realpath, stat } from 'node:fs/promises'
+import { open, readdir, readFile, realpath, stat } from 'node:fs/promises'
+import type { FileHandle } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { isAbsolute, join, relative, sep } from 'node:path'
 import type { RecentSession } from '../shared/types.ts'
@@ -26,6 +27,9 @@ interface PiSessionHeader {
 
 const MAX_SESSIONS = 30
 const CANDIDATE_BUFFER = 100
+const HEAD_CHUNK_BYTES = 64 * 1024
+const TAIL_CHUNK_BYTES = 64 * 1024
+const TAIL_SCAN_BUDGET = 2 * 1024 * 1024
 
 /** Reads only the metadata required to resume a Pi session. */
 export async function listRecentPiSessions(
@@ -94,7 +98,7 @@ async function readPiSession(path: string, updatedAt: number): Promise<RecentSes
   }
   let lines: string[]
   try {
-    lines = (await readFile(path, 'utf8')).split('\n')
+    lines = await readSessionLines(canonicalPath)
   } catch {
     return null
   }
@@ -139,6 +143,41 @@ async function readPiSession(path: string, updatedAt: number): Promise<RecentSes
     sessionPath: canonicalPath,
     updatedAt: lastMessageAt ?? (Number.isNaN(createdAt) ? updatedAt : createdAt),
   }
+}
+
+/** Reads only the head and the newest entries of a session file instead of its full history:
+ *  the header, name, and first prompt live near the start, and the newest activity at the end.
+ *  Gigabytes of middle history never need to be parsed to render the recent-session list.
+ *  A single entry may itself be huge (tool outputs), so the end is scanned backward in chunks
+ *  until a complete JSON line is found rather than assuming a fixed tail fits. */
+async function readSessionLines(path: string): Promise<string[]> {
+  const size = (await stat(path)).size
+  if (size <= HEAD_CHUNK_BYTES + TAIL_CHUNK_BYTES) return (await readFile(path, 'utf8')).split('\n')
+  let handle: FileHandle | undefined
+  try {
+    handle = await open(path, 'r')
+    const head = Buffer.alloc(HEAD_CHUNK_BYTES)
+    const { bytesRead: headBytes } = await handle.read(head, 0, HEAD_CHUNK_BYTES, 0)
+    let tail = ''
+    let position = size
+    let scanned = 0
+    while (position > HEAD_CHUNK_BYTES && scanned < TAIL_SCAN_BUDGET && !hasParseableLine(tail)) {
+      const chunkSize = Math.min(TAIL_CHUNK_BYTES, position - HEAD_CHUNK_BYTES)
+      position -= chunkSize
+      const chunk = Buffer.alloc(chunkSize)
+      const { bytesRead } = await handle.read(chunk, 0, chunkSize, position)
+      tail = chunk.subarray(0, bytesRead).toString('utf8') + tail
+      scanned += chunkSize
+    }
+    return (head.subarray(0, headBytes).toString('utf8') + tail).split('\n')
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
+
+/** True when the accumulated text contains at least one complete JSON line. */
+function hasParseableLine(text: string): boolean {
+  return text.split('\n').some((line) => parseLine(line) !== null)
 }
 
 function parseHeader(line: string | undefined): PiSessionHeader | null {

--- a/test/pi-session-store.test.ts
+++ b/test/pi-session-store.test.ts
@@ -118,6 +118,49 @@ test('uses the first non-command user prompt and hides sessions without messages
   assert.equal(recent[0].name, 'One two three four five six seven eight…')
 })
 
+test('reads the newest entry of a large session file even when it exceeds one tail chunk', async () => {
+  const { directory, workspace } = await fixture()
+  // Middle history large enough that the head+tail path is taken and real bytes are skipped.
+  const padding = JSON.stringify({
+    type: 'message',
+    timestamp: '2026-07-19T10:00:00.000Z',
+    message: { role: 'assistant', content: 'x'.repeat(150 * 1024) },
+  })
+  // The final record is larger than one 64 KiB tail chunk: the backward scan must keep going
+  // past the first chunk to capture its start, otherwise the newest entry would be dropped.
+  const finalEntry = JSON.stringify({
+    type: 'message',
+    timestamp: '2026-07-19T11:00:00.000Z',
+    message: { role: 'user', content: 'y'.repeat(70 * 1024) },
+  })
+  await writeFile(
+    join(directory, 'big.jsonl'),
+    [
+      JSON.stringify({
+        type: 'session',
+        version: 3,
+        id: 'big',
+        timestamp: '2026-07-19T09:00:00.000Z',
+        cwd: workspace,
+      }),
+      JSON.stringify({ type: 'session_info', name: 'Big session' }),
+      JSON.stringify({
+        type: 'message',
+        timestamp: '2026-07-19T09:00:00.000Z',
+        message: { role: 'user', content: 'first prompt' },
+      }),
+      padding,
+      finalEntry,
+    ]
+      .join('\n') + '\n',
+  )
+  const recent = await listRecentPiSessions(workspace, directory)
+  assert.equal(recent.length, 1)
+  assert.equal(recent[0].name, 'Big session')
+  // updatedAt reflects the final entry's timestamp; if it were ignored, this would fall back to 09:00.
+  assert.equal(recent[0].updatedAt, Date.parse('2026-07-19T11:00:00.000Z'))
+})
+
 async function writeSession(
   path: string,
   cwd: string,


### PR DESCRIPTION
## Problem

`listRecentPiSessions` read the **entire** `.jsonl` session file into memory and split it into lines just to extract the header (name, first prompt) and the newest activity. With long-running Pi sessions this file can grow to **gigabytes** of intermediate history, making the recent-session list slow to populate.

## Fix

Add `readSessionLines()` in `server/pi-session-store.ts` which reads only:
- the **first** 64 KB (header, name, first prompt), and
- the **last** entries, found by scanning **backward** in 64 KB chunks until a complete JSON line is encountered (a single entry can itself be large, so a fixed tail size is not enough).

Files smaller than 128 KB are still read in full (fast path unchanged). The backward scan is capped at a 2 MB budget so pathological cases stay bounded.

This means gigabytes of middle history are never parsed just to render the recent-session list.

## Validation

- `tsc --noEmit` — clean
- `test/pi-session-store.test.ts` (4 tests) — all pass

The lockfile churn from the original commit was deliberately excluded from this PR.