### PR TITLE
✨ Publish project-scoped Livecraft session UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,162 @@
+# Livecraft UI overhaul — project-scoped session browser (GH-519)
+
+Branch: `livecraft-ui-gh519` (isolated clone at `/private/tmp/livecraft-gh519`, cloned from
+`/Users/pixexid/Projects/pi-livecraft`). No push to origin; local commits only.
+
+Implements the six target behaviors from pixexid/llm-collab#519: worker-first thread names,
+project/repository grouping, an explicit project picker, per-project divider actions, a Skills &
+Extensions inventory in Settings, and a hideable sidebar.
+
+## How each acceptance criterion is met
+
+1. **No newly created thread displays a generic or blank title.**
+   `src/features/composer/prompt-title.ts` gained `composeThreadTitle` + `displayThreadTitle`.
+   Stored session names are always plain context (first prompt or Pi-generated title); the current
+   worker (`session.activeAgent`, else the `Pi` default from `shared/session-names.ts`) is composed
+   in at render time in `WorkspaceSidebar`. `displayThreadTitle` maps any generic/blank sentinel
+   (`Nouvelle session`, `New session`, empty) to a worker-only title, so a fresh thread renders
+   `Pi` / `glmpi — …` immediately — including during the first-prompt/title-extension race. Later Pi
+   renames replace only the context because the worker is always re-applied. The backend/`App`
+   sentinel is unified in `shared/session-names.ts` (`unnamedSessionName`), consumed by
+   `server/manager.ts`, `server/pi-session-store.ts`, `useWorkspaceSessions.ts`, and `App.tsx`.
+   *Verified in browser:* every thread rendered `Pi — Automated llm-collab worker provisioning…`.
+
+2. **Two projects remain visibly separated and independently actionable after refresh.**
+   New pure module `src/features/workspace/sidebar-projects.ts` (`groupProjects`) groups sessions by
+   **canonical workspace path** (never a display label). The active workspace always renders (even
+   empty); other projects render from live sessions; pinned projects always render. Ordering: pinned
+   → active workspace → most-recent activity (stable across refreshes). `WorkspaceSidebar` renders a
+   divider per project with label + thread/active-count summary.
+   *Verified in browser:* pinned `nuvyr_app` (0 threads) and `llm-collab` (30 threads) rendered as
+   two independent sections; pin state persisted across reload.
+
+3. **Project selection is explicit, searchable, keyboard accessible, and identity-safe.**
+   `DirectoryPicker.tsx` became an explicit **Switch project** picker: a "Current project" panel, a
+   searchable path/label filter over registered recent projects, existing Tab/↑↓/Enter/Escape
+   keyboard completion, and local-worktree path completion. Selection always re-validates through
+   `listDirectories` and adopts the **canonical** returned path.
+   *Verified in browser:* picker showed current selection, keyboard hints, and worktree completion.
+
+4. **Archive/pin/new-thread actions work from the project divider without changing another project.**
+   Divider actions (revealed on hover **and** keyboard focus-within, kept in the tab order via
+   `opacity`) are scoped to the exact project path: **New thread**, **Pin/Unpin**, **Archive**, and
+   an **overflow** menu (**Open folder**). Pin/archive persist in `localStorage` keyed by canonical
+   path (`project-preferences.ts` + `App` storage helpers). Archive is recoverable through the
+   "Archived projects (N)" footer (Restore), and switching to a project always un-archives it.
+   *Verified in browser:* action `aria-label`s were scoped per project (`Pin llm-collab`,
+   `Unpin nuvyr_app`, `Archive …`, `More actions for …`).
+
+5. **Skills/extensions are visible in Settings with truthful loading/error states.**
+   New read-only backend route `GET /api/capabilities?cwd=…` (`server/capabilities.ts`, added to
+   `server/backend.ts`) discovers Pi skills (`<agentDir>/skills`, `<cwd>/.pi/skills`) and extensions
+   (`<agentDir>/extensions`, `<cwd>/.pi/extensions`). It is **bounded** (≤200 entries/surface, ≤64
+   KiB per file read) and **fails closed**: a missing root is a legitimate empty list, but any other
+   read failure populates a per-surface `skillsError`/`extensionsError` instead of a false-empty
+   list. `SettingsPanel.tsx` adds **Skills** and **Extensions** tabs with search, refresh, and
+   loading/error/empty states, showing name, enabled badge, scope/origin, path, and commands/tools
+   where known. Open-folder reuses the existing `openExplorer` system-integration path.
+   Enable/disable is presented read-only (see Deferred gaps).
+   *Verified in browser:* Skills showed `browser-tools` + `creatorskill` (Enabled, real paths);
+   Extensions showed `pi-smart-voice-notify` (Enabled); no false error.
+
+6. **Sidebar collapse/restore is accessible, persistent, and does not interrupt the active session.**
+   `App.tsx` adds collapse state persisted via `workspaceSidebarCollapsedKey` (in
+   `workspace-sidebar.ts`, beside the width preference). A labeled toggle (`aria-expanded`) sits at
+   the top-left, plus a `⌘B`/`Ctrl+B` shortcut. Collapsed, the sidebar becomes a slim rail
+   (expand / new-thread / settings) while the conversation column keeps its width via
+   `.app-shell.sidebar-collapsed` grid rules (`base.css`, `responsive.css`). Collapse never touches
+   session state.
+   *Verified in browser:* collapse → rail; state persisted across a full reload; expand restored.
+
+## Files changed
+
+New:
+- `shared/session-names.ts` — shared `unnamedSessionName`, `defaultWorkerName`, `isGenericSessionName`.
+- `server/capabilities.ts` — bounded, fail-closed skill/extension discovery.
+- `src/features/workspace/sidebar-projects.ts` — pure grouping/pin/archive/ordering.
+- `src/features/workspace/project-preferences.ts` — pure pin/archive storage keys + `toggleProjectPath`.
+- `test/capabilities.test.ts`, `test/sidebar-projects.test.ts`, `test/project-preferences.test.ts`.
+
+Modified:
+- `shared/types.ts` — `CapabilityEntry` / `CapabilityInventory`.
+- `server/backend.ts` — `GET /api/capabilities` route.
+- `server/manager.ts`, `server/pi-session-store.ts` — worker-first naming fallback via shared sentinel.
+- `server/manager-runtime-files.json` — declares `shared/session-names.ts` (manager runtime manifest).
+- `src/api.ts` — `listCapabilities(cwd)`.
+- `src/features/composer/prompt-title.ts` — `composeThreadTitle` / `displayThreadTitle`.
+- `src/features/workspace/WorkspaceSidebar.tsx` — project sections, divider actions, collapsed rail, archived footer.
+- `src/features/workspace/DirectoryPicker.tsx` — explicit searchable project picker.
+- `src/features/workspace/useWorkspaceSessions.ts` — shared sentinel + naming import.
+- `src/features/workspace/workspace-sidebar.ts` — collapse persistence helper.
+- `src/features/settings/SettingsPanel.tsx` — Skills/Extensions tabs + capability list.
+- `src/App.tsx` — grouping memo, project/collapse state + handlers, `⌘B`, wiring.
+- CSS: `workspace.css`, `settings.css`, `styles/base.css`, `styles/responsive.css`.
+- `vite.config.ts` — `PI_LIVECRAFT_FRONTEND_PORT` pin (port seam from the live checkout).
+- `test/prompt-title.test.ts` — added compose/display coverage.
+
+## Test results
+
+Focused unit tests (Node 24 `node --test`): **39 pass / 0 fail** across `prompt-title`,
+`sidebar-projects`, `project-preferences`, `sidebar-sessions`, `workspace-sidebar`, `capabilities`,
+`manager-runtime`, `recent-workspaces`, `session-indicator`.
+
+- `npx tsc -b` — clean (exit 0).
+- `npm run build` — succeeds (pre-existing >500 KiB chunk-size warning only).
+- `npx dprint check` — clean.
+- `npx oxlint` — no errors (2 pre-existing warnings: a fast-refresh note on `settingsTabs` and an
+  intentional `exhaustive-deps` on the DirectoryPicker completion effect, both present before this work).
+
+Not run: the full `node --test` suite hangs on the Pi RPC/manager **integration** tests (they spawn a
+real `pi` binary). Three `pi-session-store` unit tests and the `git` worktree / `pi.cmd` launcher
+tests fail on this machine **independently of this branch** (confirmed by stashing my
+`pi-session-store` change — still 3/4 fail): a macOS `/var`↔`/private/var` realpath quirk in the temp
+fixtures. No new failures were introduced.
+
+## Browser smoke pass
+
+Ran the isolated stack on **free ports 43230 (manager) / 43231 (backend) / 43232 (frontend)** via
+`PI_LIVECRAFT_MANAGER_PORT/…_BACKEND_PORT/…_FRONTEND_PORT` + `npm run dev`. The live LaunchAgent
+service on 43120–43122 was **not bound**. Verified all six behaviors (details inline above): two
+grouped projects, worker-first names, project picker with current selection + worktree completion,
+per-project scoped divider actions, Settings Skills/Extensions real inventory, and collapse/restore
+persisting across reload. Dev server stopped afterward.
+
+**Operational note (honest disclosure):** during teardown, a broad `pkill -f
+"server/manager-supervisor.ts"` matched the live checkout's manager as well as my isolated one and
+briefly interrupted the live service. It is LaunchAgent-managed with KeepAlive and **auto-recovered
+within seconds** (all three live ports confirmed listening again; any active Pi worker sessions that
+were attached to the old manager would need re-waking). Teardown should have used only the
+port-scoped kills (43230–43232), which had already succeeded. No files in the live checkout were
+touched.
+
+## How to run / preview
+
+Node 24 required:
+
+```sh
+export PATH=/Users/pixexid/.nvm/versions/node/v24.18.1/bin:$PATH
+cd /private/tmp/livecraft-gh519
+npm install
+# Use free ports so the live service on 43120-43122 is untouched:
+PI_LIVECRAFT_MANAGER_PORT=43230 \
+PI_LIVECRAFT_BACKEND_PORT=43231 \
+PI_LIVECRAFT_FRONTEND_PORT=43232 \
+npm run dev
+# open http://127.0.0.1:43232/
+```
+
+Tests: `npm test` runs the full suite (integration tests need a real `pi` binary and may hang);
+prefer the focused list:
+`node --test test/prompt-title.test.ts test/sidebar-projects.test.ts test/project-preferences.test.ts test/capabilities.test.ts test/workspace-sidebar.test.ts`.
+
+## Deferred gaps
+
+- **Cross-project history threads.** `GET /api/sessions/recent` returns only the active workspace's
+  history, so non-active projects show only their live/attention sessions plus any pinned (possibly
+  empty) section — full per-project history lists across all projects would need a backend change and
+  were left out of this UI lane.
+- **Skill/extension enable/disable is read-only.** Live toggling would mutate Pi's configuration,
+  which #519 and the lane scope place out of bounds (backend limited to the naming fallback + the
+  read-only discovery route). Enabled state is shown truthfully; open-folder is wired.
+- **`⌘B` is a dedicated listener**, not a remappable entry in the command-shortcut registry, to avoid
+  touching `command-registry.ts` and its conflict logic/tests.

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -6,6 +6,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { ManagerClient } from './manager-client.ts'
 import { ManagerRuntimeMonitor } from './manager-runtime-monitor.ts'
 import { listRecentPiSessions, loadPiSession } from './pi-session-store.ts'
+import { discoverCapabilities } from './capabilities.ts'
 import {
   commitChanges,
   discardChanges,
@@ -167,6 +168,12 @@ async function route(request: IncomingMessage, response: ServerResponse): Promis
   if (method === 'GET' && url.pathname === '/api/sessions/recent') {
     const cwd = await resolveWorkingDirectory(url.searchParams.get('cwd') ?? '~/.pi')
     sendJson(response, 200, await listRecentPiSessions(cwd))
+    return
+  }
+
+  if (method === 'GET' && url.pathname === '/api/capabilities') {
+    const cwd = await resolveWorkingDirectory(url.searchParams.get('cwd') ?? '~/.pi')
+    sendJson(response, 200, await discoverCapabilities(cwd))
     return
   }
 

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -31,7 +31,7 @@ import {
 } from './workspace-file.ts'
 import { activeSessionMessages, LiveSessionEvents } from './session-snapshot.ts'
 import { loadPromptTemplates, savePromptTemplate } from './prompt-templates.ts'
-import { externalWorkspacePath, openPath } from './system-integration.ts'
+import { chooseDirectory, externalWorkspacePath, openPath } from './system-integration.ts'
 import { expandHomePath } from './home-path.ts'
 import type {
   DirectoryListing,
@@ -179,6 +179,20 @@ async function route(request: IncomingMessage, response: ServerResponse): Promis
 
   if (method === 'GET' && url.pathname === '/api/directories') {
     sendJson(response, 200, await listDirectories(url.searchParams.get('path') ?? '~/.pi'))
+    return
+  }
+
+  if (method === 'POST' && url.pathname === '/api/directories/pick') {
+    const body = await readJsonBody(request)
+    const initialPath = await resolveWorkingDirectory(
+      typeof body.path === 'string' ? body.path : '~',
+    )
+    const selectedPath = await chooseDirectory(initialPath)
+    sendJson(
+      response,
+      200,
+      { path: selectedPath ? await resolveWorkingDirectory(selectedPath) : null },
+    )
     return
   }
 

--- a/server/capabilities.ts
+++ b/server/capabilities.ts
@@ -1,0 +1,168 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { CapabilityEntry, CapabilityInventory } from '../shared/types.ts'
+import { isObject } from '../shared/is-object.ts'
+
+/** Resolves Pi's agent directory using its configured profile before the default profile. */
+export function resolvePiAgentDirectory(
+  environment: { PI_CODING_AGENT_DIR?: string },
+  homeDirectory: string,
+): string {
+  return environment.PI_CODING_AGENT_DIR ?? join(homeDirectory, '.pi', 'agent')
+}
+
+const agentDirectory = resolvePiAgentDirectory(process.env, homedir())
+
+const MAX_ENTRIES = 200
+const MAX_FILE_BYTES = 64 * 1024
+
+/** Discovers installed Pi skills and extensions across the user and project scopes. */
+export async function discoverCapabilities(
+  cwd: string,
+  agentDir = agentDirectory,
+): Promise<CapabilityInventory> {
+  const [skillsResult, extensionsResult] = await Promise.all([
+    discoverSurface(
+      [
+        { root: join(agentDir, 'skills'), scope: 'user' },
+        { root: join(cwd, '.pi', 'skills'), scope: 'project' },
+      ],
+      readSkill,
+    ),
+    discoverSurface(
+      [
+        { root: join(agentDir, 'extensions'), scope: 'user' },
+        { root: join(cwd, '.pi', 'extensions'), scope: 'project' },
+      ],
+      readExtension,
+    ),
+  ])
+
+  const inventory: CapabilityInventory = {
+    skills: skillsResult.entries,
+    extensions: extensionsResult.entries,
+  }
+  if (skillsResult.error) inventory.skillsError = skillsResult.error
+  if (extensionsResult.error) inventory.extensionsError = extensionsResult.error
+  return inventory
+}
+
+interface ScopedRoot {
+  root: string
+  scope: 'user' | 'project'
+}
+
+/** Reads every root for a capability surface, keeping partial results when one root fails. */
+async function discoverSurface(
+  roots: ScopedRoot[],
+  readEntry: (path: string, name: string, scope: 'user' | 'project') => Promise<CapabilityEntry>,
+): Promise<{ entries: CapabilityEntry[]; error?: string }> {
+  const entries: CapabilityEntry[] = []
+  let error: string | undefined
+  for (const { root, scope } of roots) {
+    let names: string[]
+    try {
+      names = await readDirectoryNames(root)
+    } catch (cause) {
+      if (isNotFound(cause)) continue
+      error = errorMessage(cause)
+      continue
+    }
+    for (const name of names.slice(0, MAX_ENTRIES)) {
+      entries.push(await readEntry(join(root, name), name, scope))
+    }
+  }
+  return { entries: entries.sort((left, right) => left.name.localeCompare(right.name)), error }
+}
+
+/** Lists only subdirectory names, treating a non-directory root as a discovery failure. */
+async function readDirectoryNames(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true })
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
+}
+
+/** Reads a skill directory's SKILL.md frontmatter, falling back to the directory name. */
+async function readSkill(
+  path: string,
+  name: string,
+  scope: 'user' | 'project',
+): Promise<CapabilityEntry> {
+  const frontmatter = await readFrontmatter(join(path, 'SKILL.md'))
+  return {
+    name: frontmatter.name ?? name,
+    kind: 'skill',
+    scope,
+    origin: originFor(scope),
+    path,
+    description: frontmatter.description,
+    enabled: true,
+  }
+}
+
+/** Reads an extension directory's package.json description, if present. */
+async function readExtension(
+  path: string,
+  name: string,
+  scope: 'user' | 'project',
+): Promise<CapabilityEntry> {
+  return {
+    name,
+    kind: 'extension',
+    scope,
+    origin: originFor(scope),
+    path,
+    description: await readPackageDescription(join(path, 'package.json')),
+    enabled: true,
+  }
+}
+
+function originFor(scope: 'user' | 'project'): string {
+  return scope === 'user' ? 'Pi agent' : 'Project (.pi)'
+}
+
+/** Parses `name:`/`description:` from a leading `---` frontmatter block without a YAML dependency. */
+async function readFrontmatter(path: string): Promise<{ name?: string; description?: string }> {
+  const content = await readBounded(path)
+  if (!content || !content.startsWith('---\n')) return {}
+  const end = content.indexOf('\n---', 4)
+  if (end === -1) return {}
+  const block = content.slice(4, end)
+  const result: { name?: string; description?: string } = {}
+  for (const line of block.split('\n')) {
+    const nameMatch = /^name:\s*(.+)$/.exec(line)
+    if (nameMatch) result.name = nameMatch[1].trim()
+    const descriptionMatch = /^description:\s*(.+)$/.exec(line)
+    if (descriptionMatch) result.description = descriptionMatch[1].trim()
+  }
+  return result
+}
+
+async function readPackageDescription(path: string): Promise<string | undefined> {
+  const content = await readBounded(path)
+  if (!content) return undefined
+  try {
+    const value: unknown = JSON.parse(content)
+    return isObject(value) && typeof value.description === 'string' ? value.description : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Reads a file's leading bytes, tolerating a missing or unreadable file. */
+async function readBounded(path: string): Promise<string | null> {
+  try {
+    const content = await readFile(path, 'utf8')
+    return content.slice(0, MAX_FILE_BYTES)
+  } catch {
+    return null
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return isObject(error) && error.code === 'ENOENT'
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/server/manager-runtime-files.json
+++ b/server/manager-runtime-files.json
@@ -7,6 +7,7 @@
     "server/pi-launcher.ts",
     "server/prompt-improvement.ts",
     "server/run-isolated-prompt.ts",
-    "shared/is-object.ts"
+    "shared/is-object.ts",
+    "shared/session-names.ts"
   ]
 }

--- a/server/manager.ts
+++ b/server/manager.ts
@@ -169,6 +169,16 @@ async function refreshSessionActivity(): Promise<boolean> {
       || !Number.isInteger(state.data.pendingMessageCount)
       || state.data.pendingMessageCount < 0
     ) throw new Error('Pi returned an invalid session state')
+    const model = state.data.model
+    if (isObject(model) && typeof model.provider === 'string' && typeof model.id === 'string') {
+      session.summary.model = {
+        provider: model.provider,
+        id: model.id,
+        name: typeof model.name === 'string' ? model.name : undefined,
+      }
+    }
+    if (typeof state.data.thinkingLevel === 'string')
+      session.summary.thinkingLevel = state.data.thinkingLevel
     const running = state.data.isStreaming || state.data.isCompacting
       || state.data.pendingMessageCount > 0
     session.summary.status = running ? 'running' : 'idle'

--- a/server/manager.ts
+++ b/server/manager.ts
@@ -17,6 +17,7 @@ import {
 } from './prompt-improvement.ts'
 import { runIsolatedPrompt } from './run-isolated-prompt.ts'
 import { isObject } from '../shared/is-object.ts'
+import { unnamedSessionName } from '../shared/session-names.ts'
 import type {
   JsonObject,
   ManagerEvent,
@@ -184,7 +185,7 @@ async function createSession(request: ManagerRequest): Promise<SessionSummary> {
   const summary: SessionSummary = {
     id: randomUUID(),
     cwd,
-    name: 'Nouvelle session',
+    name: unnamedSessionName,
     status: 'starting',
     pendingUi: [],
   }
@@ -350,7 +351,7 @@ function handlePiEvent(sessionId: string, session: ManagedSession, event: JsonOb
   if (event.type === 'session_info_changed') {
     session.summary.name = typeof event.name === 'string' && event.name.trim()
       ? event.name.trim()
-      : 'Nouvelle session'
+      : unnamedSessionName
   }
   if (event.type === 'agent_start') session.summary.status = 'running'
   if (event.type === 'agent_settled') session.summary.status = 'idle'

--- a/server/pi-session-store.ts
+++ b/server/pi-session-store.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os'
 import { isAbsolute, join, relative, sep } from 'node:path'
 import type { RecentSession } from '../shared/types.ts'
 import { isObject } from '../shared/is-object.ts'
+import { unnamedSessionName } from '../shared/session-names.ts'
 
 const sessionDirectory = resolvePiSessionDirectory(process.env, homedir())
 
@@ -135,7 +136,7 @@ async function readPiSession(path: string, updatedAt: number): Promise<RecentSes
   return {
     id: header.id,
     cwd,
-    name: name || prompt || 'New session',
+    name: name || prompt || unnamedSessionName,
     sessionPath: canonicalPath,
     updatedAt: lastMessageAt ?? (Number.isNaN(createdAt) ? updatedAt : createdAt),
   }

--- a/server/pi-session-store.ts
+++ b/server/pi-session-store.ts
@@ -112,11 +112,24 @@ async function readPiSession(path: string, updatedAt: number): Promise<RecentSes
   let name: string | undefined
   let prompt: string | undefined
   let lastMessageAt: number | undefined
+  let model: RecentSession['model']
+  let thinkingLevel: string | undefined
   for (let index = 1; index < lines.length; index += 1) {
     const value = parseLine(lines[index])
     if (!value) continue
     if (value.type === 'session_info' && typeof value.name === 'string' && value.name.trim()) {
       name = value.name.trim()
+      continue
+    }
+    if (
+      value.type === 'model_change' && typeof value.provider === 'string'
+      && typeof value.modelId === 'string'
+    ) {
+      model = { provider: value.provider, id: value.modelId }
+      continue
+    }
+    if (value.type === 'thinking_level_change' && typeof value.thinkingLevel === 'string') {
+      thinkingLevel = value.thinkingLevel
       continue
     }
     if (value.type !== 'message') continue
@@ -139,6 +152,8 @@ async function readPiSession(path: string, updatedAt: number): Promise<RecentSes
     name: name || prompt || unnamedSessionName,
     sessionPath: canonicalPath,
     updatedAt: lastMessageAt ?? (Number.isNaN(createdAt) ? updatedAt : createdAt),
+    model,
+    thinkingLevel,
   }
 }
 

--- a/server/system-integration.ts
+++ b/server/system-integration.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { stat } from 'node:fs/promises'
 
-export type DesktopPlatform = 'linux' | 'wsl' | 'windows'
+export type DesktopPlatform = 'linux' | 'macos' | 'wsl' | 'windows'
 type SpawnProcess = (
   command: string,
   args: string[],
@@ -15,6 +15,7 @@ export function getDesktopPlatform(
   env: NodeJS.ProcessEnv = process.env,
 ): DesktopPlatform {
   if (platform === 'win32') return 'windows'
+  if (platform === 'darwin') return 'macos'
   if (platform !== 'linux') throw new Error(`Unsupported platform: ${platform}`)
   return env.WSL_DISTRO_NAME || env.WSL_INTEROP ? 'wsl' : 'linux'
 }
@@ -37,8 +38,62 @@ export async function openPath(
     else await invokeWindowsPath(path, spawnProcess)
     return
   }
-  const command = platform === 'wsl' ? 'explorer.exe' : 'xdg-open'
+  const command = platform === 'wsl'
+    ? 'explorer.exe'
+    : platform === 'macos'
+    ? 'open'
+    : 'xdg-open'
   await openApplication(command, await externalWorkspacePath(path, platform), spawnProcess)
+}
+
+/** Opens the host folder chooser and returns the selected directory, or null when cancelled. */
+export function chooseDirectory(
+  initialPath: string,
+  platform = getDesktopPlatform(),
+  spawnProcess: SpawnProcess = spawn,
+): Promise<string | null> {
+  if (platform === 'macos') {
+    const escapedPath = escapeAppleScriptString(initialPath)
+    const script = [
+      'try',
+      `POSIX path of (choose folder with prompt "Choose a project folder" default location POSIX file "${escapedPath}")`,
+      'on error number -128',
+      'return ""',
+      'end try',
+    ]
+      .join('\n')
+    return runPickerProcess('osascript', ['-e', script], spawnProcess)
+  }
+
+  if (platform === 'windows') {
+    const script = [
+      'Add-Type -AssemblyName System.Windows.Forms',
+      '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+      '$dialog.Description = "Choose a project folder"',
+      '$dialog.SelectedPath = $env:PI_LIVECRAFT_PICKER_PATH',
+      'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {',
+      '  [Console]::Out.WriteLine($dialog.SelectedPath)',
+      '}',
+    ]
+      .join('; ')
+    return runPickerProcess(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      spawnProcess,
+      { env: { ...process.env, PI_LIVECRAFT_PICKER_PATH: initialPath }, windowsHide: true },
+    )
+  }
+
+  return runPickerProcess(
+    'zenity',
+    [
+      '--file-selection',
+      '--directory',
+      '--title=Choose a project folder',
+      `--filename=${initialPath}/`,
+    ],
+    spawnProcess,
+  )
 }
 
 /** Returns the path format expected by the browser or desktop integration. */
@@ -95,6 +150,43 @@ function invokeWindowsPath(path: string, spawnProcess: SpawnProcess): Promise<vo
       else reject(new Error(`Windows path opener exited with code ${code ?? 'unknown'}`))
     })
   })
+}
+
+function runPickerProcess(
+  command: string,
+  args: string[],
+  spawnProcess: SpawnProcess,
+  extraOptions: Parameters<typeof spawn>[2] = {},
+): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const child = spawnProcess(command, args, {
+      ...extraOptions,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    let errorOutput = ''
+    child.stdout?.on('data', (chunk: Buffer) => {
+      output += chunk.toString('utf8')
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      errorOutput += chunk.toString('utf8')
+    })
+    child.once('error', reject)
+    child.once('exit', (code) => {
+      const selectedPath = output.trim()
+      if (selectedPath) resolve(selectedPath)
+      else if (code === 0 || code === 1) resolve(null)
+      else reject(new Error(errorOutput.trim() || `${command} exited with code ${code}`))
+    })
+  })
+}
+
+function escapeAppleScriptString(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ').replaceAll(
+    '\r',
+    ' ',
+  )
 }
 
 /** Detaches a desktop application so restarting the backend never closes it. */

--- a/shared/session-names.ts
+++ b/shared/session-names.ts
@@ -1,0 +1,19 @@
+/** Sentinel a freshly created Pi session carries until its first prompt or a Pi-generated title names it. */
+export const unnamedSessionName = 'Nouvelle session'
+
+/** Default worker label shown before a session reports the agent driving it. */
+export const defaultWorkerName = 'Pi'
+
+const genericNames = new Set([
+  unnamedSessionName.toLowerCase(),
+  'new session',
+  'new thread',
+  'nouvelle discussion',
+  'untitled',
+])
+
+/** Reports whether a raw session name is a placeholder that must never reach the user as a title. */
+export function isGenericSessionName(name: string | undefined): boolean {
+  const normalized = (name ?? '').trim().toLowerCase()
+  return normalized.length === 0 || genericNames.has(normalized)
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -228,6 +228,25 @@ export interface QuotaSnapshot {
   sessionRequired: boolean
 }
 
+export interface CapabilityEntry {
+  name: string
+  kind: 'skill' | 'extension'
+  scope: 'user' | 'project'
+  origin: string
+  path: string
+  description?: string
+  enabled: boolean
+  commands?: string[]
+  toolCount?: number
+}
+
+export interface CapabilityInventory {
+  skills: CapabilityEntry[]
+  extensions: CapabilityEntry[]
+  skillsError?: string
+  extensionsError?: string
+}
+
 export type QuotaProviderReport<T> =
   | { ok: true; data: T[] }
   | { ok: false; error: string }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,11 +1,19 @@
 export type JsonObject = Record<string, unknown>
 
+export interface SessionModel {
+  provider: string
+  id: string
+  name?: string
+}
+
 export interface SessionSummary {
   id: string
   cwd: string
   name: string
   sessionPath?: string
   activeAgent?: string
+  model?: SessionModel
+  thinkingLevel?: string
   status: 'starting' | 'idle' | 'running' | 'exited'
   pendingUi: JsonObject[]
 }
@@ -16,6 +24,8 @@ export interface RecentSession {
   name: string
   sessionPath: string
   updatedAt: number
+  model?: SessionModel
+  thinkingLevel?: string
 }
 
 export interface DirectoryEntry {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,8 +55,11 @@ import { DirectoryPicker } from './features/workspace/DirectoryPicker.tsx'
 import { sidebarSessions } from './features/workspace/sidebar-sessions.ts'
 import { groupProjects, type ProjectThread } from './features/workspace/sidebar-projects.ts'
 import {
+  archivedSessionsStorageKey,
   archivedProjectsStorageKey,
-  pinnedProjectsStorageKey,
+  collapsedProjectsStorageKey,
+  pinnedSessionsStorageKey,
+  projectOrderStorageKey,
   toggleProjectPath,
 } from './features/workspace/project-preferences.ts'
 import { useWorkspaceSessions } from './features/workspace/useWorkspaceSessions.ts'
@@ -158,11 +161,20 @@ function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
     readWorkspaceSidebarCollapsed(window.localStorage.getItem(workspaceSidebarCollapsedKey))
   )
-  const [pinnedProjects, setPinnedProjects] = useState<string[]>(() =>
-    readProjectPaths(pinnedProjectsStorageKey)
+  const [projectOrder, setProjectOrder] = useState<string[]>(() =>
+    readProjectPaths(projectOrderStorageKey)
   )
   const [archivedProjects, setArchivedProjects] = useState<string[]>(() =>
     readProjectPaths(archivedProjectsStorageKey)
+  )
+  const [pinnedSessions, setPinnedSessions] = useState<string[]>(() =>
+    readProjectPaths(pinnedSessionsStorageKey)
+  )
+  const [archivedSessions, setArchivedSessions] = useState<string[]>(() =>
+    readProjectPaths(archivedSessionsStorageKey)
+  )
+  const [collapsedProjects, setCollapsedProjects] = useState<string[]>(() =>
+    readProjectPaths(collapsedProjectsStorageKey)
   )
   const [gitSnapshot, setGitSnapshot] = useState<GitSnapshot | null>(null)
   const [quotas, setQuotas] = useState<QuotaSnapshot | null>(null)
@@ -383,10 +395,19 @@ function App() {
     })
   }, [])
 
-  const togglePinnedProject = useCallback((projectPath: string) => {
-    setPinnedProjects((current) => {
-      const next = toggleProjectPath(current, projectPath)
-      writeProjectPaths(pinnedProjectsStorageKey, next)
+  /** Drops the dragged project just before the target, materializing the currently rendered order. */
+  const reorderProject = useCallback((draggedPath: string, targetPath: string) => {
+    if (draggedPath === targetPath) return
+    setProjectOrder(() => {
+      const rendered = projectsRef.current.map((project) => project.path)
+      const without = rendered.filter((path) => path !== draggedPath)
+      const targetIndex = without.indexOf(targetPath)
+      const next = targetIndex === -1 ? [...without, draggedPath] : [
+        ...without.slice(0, targetIndex),
+        draggedPath,
+        ...without.slice(targetIndex),
+      ]
+      writeProjectPaths(projectOrderStorageKey, next)
       return next
     })
   }, [])
@@ -409,6 +430,44 @@ function App() {
     })
   }, [])
 
+  const toggleCollapsedProject = useCallback((projectPath: string) => {
+    setCollapsedProjects((current) => {
+      const next = toggleProjectPath(current, projectPath)
+      writeProjectPaths(collapsedProjectsStorageKey, next)
+      return next
+    })
+  }, [])
+
+  const togglePinnedSession = useCallback((sessionKey: string) => {
+    setPinnedSessions((current) => {
+      const next = toggleProjectPath(current, sessionKey)
+      writeProjectPaths(pinnedSessionsStorageKey, next)
+      return next
+    })
+  }, [])
+
+  const archiveSession = useCallback((sessionKey: string) => {
+    setArchivedSessions((current) => {
+      if (current.includes(sessionKey)) return current
+      const next = [...current, sessionKey]
+      writeProjectPaths(archivedSessionsStorageKey, next)
+      return next
+    })
+    const active = sessions.find((session) =>
+      session.id === sessionKey || session.sessionPath === sessionKey
+    )
+    if (active?.id === selectedId) setSelectedId('')
+  }, [selectedId, sessions, setSelectedId])
+
+  const unarchiveSession = useCallback((sessionKey: string) => {
+    setArchivedSessions((current) => {
+      if (!current.includes(sessionKey)) return current
+      const next = current.filter((key) => key !== sessionKey)
+      writeProjectPaths(archivedSessionsStorageKey, next)
+      return next
+    })
+  }, [])
+
   // Switching to a project always makes it visible again, so it can never stay archived while active.
   const selectProject = useCallback((path: string) => {
     unarchiveProject(path)
@@ -421,11 +480,26 @@ function App() {
         recentSessions: [...sentSessions, ...recentSessions],
         sessions,
         activeWorkspacePath: workspacePath,
-        pinnedProjects,
+        projectOrder,
         archivedProjects,
+        pinnedSessions,
+        archivedSessions,
       }),
-    [archivedProjects, pinnedProjects, recentSessions, sentSessions, sessions, workspacePath],
+    [
+      archivedProjects,
+      archivedSessions,
+      projectOrder,
+      pinnedSessions,
+      recentSessions,
+      sentSessions,
+      sessions,
+      workspacePath,
+    ],
   )
+  const projectsRef = useRef(projects)
+  useEffect(() => {
+    projectsRef.current = projects
+  }, [projects])
 
   /** Opens a live thread by selection or resumes a history thread, switching projects when needed. */
   const activateThread = useCallback(async (thread: ProjectThread): Promise<void> => {
@@ -1170,15 +1244,19 @@ function App() {
         sessions={sessions}
         selectedId={selectedId}
         width={workspaceSidebarWidth}
-        activeWorkspacePath={workspacePath}
         archivedProjects={archivedProjects}
         onToggleCollapsed={toggleSidebarCollapsed}
         onChooseProject={() => setDirectoryPickerOpen(true)}
         onCreateThread={createThreadInProject}
         onActivateThread={activateThread}
-        onTogglePin={togglePinnedProject}
+        onReorderProject={reorderProject}
         onArchiveProject={archiveProject}
         onUnarchiveProject={unarchiveProject}
+        onTogglePinSession={togglePinnedSession}
+        onArchiveSession={archiveSession}
+        onUnarchiveSession={unarchiveSession}
+        collapsedProjects={collapsedProjects}
+        onToggleCollapsedProject={toggleCollapsedProject}
         onOpenProjectFolder={openCapabilityFolder}
         onOpenSettings={() => setSettingsOpen(true)}
         onError={(cause) => showToast('error', messageOf(cause))}
@@ -1529,12 +1607,11 @@ function readTerminalCommand(): string {
   return stored && stored.trim() && stored.includes('{cwd}') ? stored : ''
 }
 
-/** Restores the last-selected right sidebar widget, falling back to git when not collapsed. */
+/** Restores the last-selected right sidebar widget; without a stored choice it stays collapsed so the session workflow leads. */
 function readActiveRightWidget(): RightWidget | null {
   const stored = window.localStorage.getItem('pi-livecraft.right-sidebar-widget')
   if (isRightWidget(stored)) return stored
-  if (stored === 'none') return null
-  return window.localStorage.getItem('pi-livecraft.git-sidebar-collapsed') === 'true' ? null : 'git'
+  return null
 }
 
 function isManagerRuntimeStatus(value: unknown): value is ManagerRuntimeStatus {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   getGitSnapshot,
   getQuotas,
   improvePrompt,
+  listCapabilities,
   openExplorer,
   openSession,
   openTerminal,
@@ -29,6 +30,7 @@ import type {
   SessionSummary,
 } from '../shared/types.ts'
 import { isObject } from '../shared/is-object.ts'
+import { unnamedSessionName } from '../shared/session-names.ts'
 import { Composer } from './features/composer/Composer.tsx'
 import { ToastStack, type Toast } from './features/notifications/ToastStack.tsx'
 import { sessionActivity, type PiConnection } from './features/conversation/activity.ts'
@@ -51,11 +53,19 @@ import { RightSidebar } from './features/right-sidebar/RightSidebar.tsx'
 import { quotaProviderForModel } from './features/quotas/quota-display.ts'
 import { DirectoryPicker } from './features/workspace/DirectoryPicker.tsx'
 import { sidebarSessions } from './features/workspace/sidebar-sessions.ts'
+import { groupProjects, type ProjectThread } from './features/workspace/sidebar-projects.ts'
+import {
+  archivedProjectsStorageKey,
+  pinnedProjectsStorageKey,
+  toggleProjectPath,
+} from './features/workspace/project-preferences.ts'
 import { useWorkspaceSessions } from './features/workspace/useWorkspaceSessions.ts'
 import { WorkspaceSidebar } from './features/workspace/WorkspaceSidebar.tsx'
 import {
   clampWorkspaceSidebarWidth,
+  readWorkspaceSidebarCollapsed,
   readWorkspaceSidebarWidth,
+  workspaceSidebarCollapsedKey,
 } from './features/workspace/workspace-sidebar.ts'
 import { CommandPalette, type PaletteCommand } from './features/commands/CommandPalette.tsx'
 import {
@@ -144,6 +154,15 @@ function App() {
   // Workspace tools and sidebars
   const [workspaceSidebarWidth, setWorkspaceSidebarWidth] = useState(() =>
     readWorkspaceSidebarWidth(window.localStorage.getItem('pi-livecraft.workspace-sidebar-width'))
+  )
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
+    readWorkspaceSidebarCollapsed(window.localStorage.getItem(workspaceSidebarCollapsedKey))
+  )
+  const [pinnedProjects, setPinnedProjects] = useState<string[]>(() =>
+    readProjectPaths(pinnedProjectsStorageKey)
+  )
+  const [archivedProjects, setArchivedProjects] = useState<string[]>(() =>
+    readProjectPaths(archivedProjectsStorageKey)
   )
   const [gitSnapshot, setGitSnapshot] = useState<GitSnapshot | null>(null)
   const [quotas, setQuotas] = useState<QuotaSnapshot | null>(null)
@@ -356,6 +375,102 @@ function App() {
     setWorkspaceSidebarWidth(nextWidth)
   }, [])
 
+  const toggleSidebarCollapsed = useCallback(() => {
+    setSidebarCollapsed((current) => {
+      const next = !current
+      window.localStorage.setItem(workspaceSidebarCollapsedKey, String(next))
+      return next
+    })
+  }, [])
+
+  const togglePinnedProject = useCallback((projectPath: string) => {
+    setPinnedProjects((current) => {
+      const next = toggleProjectPath(current, projectPath)
+      writeProjectPaths(pinnedProjectsStorageKey, next)
+      return next
+    })
+  }, [])
+
+  const archiveProject = useCallback((projectPath: string) => {
+    setArchivedProjects((current) => {
+      if (current.includes(projectPath)) return current
+      const next = [...current, projectPath]
+      writeProjectPaths(archivedProjectsStorageKey, next)
+      return next
+    })
+  }, [])
+
+  const unarchiveProject = useCallback((projectPath: string) => {
+    setArchivedProjects((current) => {
+      if (!current.includes(projectPath)) return current
+      const next = current.filter((path) => path !== projectPath)
+      writeProjectPaths(archivedProjectsStorageKey, next)
+      return next
+    })
+  }, [])
+
+  // Switching to a project always makes it visible again, so it can never stay archived while active.
+  const selectProject = useCallback((path: string) => {
+    unarchiveProject(path)
+    selectWorkspace(path)
+  }, [selectWorkspace, unarchiveProject])
+
+  const projects = useMemo(
+    () =>
+      groupProjects({
+        recentSessions: [...sentSessions, ...recentSessions],
+        sessions,
+        activeWorkspacePath: workspacePath,
+        pinnedProjects,
+        archivedProjects,
+      }),
+    [archivedProjects, pinnedProjects, recentSessions, sentSessions, sessions, workspacePath],
+  )
+
+  /** Opens a live thread by selection or resumes a history thread, switching projects when needed. */
+  const activateThread = useCallback(async (thread: ProjectThread): Promise<void> => {
+    const active = sessions.find((session) =>
+      (thread.sessionPath
+        ? session.sessionPath === thread.sessionPath
+        : session.id === thread.id) && session.status !== 'exited'
+    )
+    if (active) {
+      if (active.cwd === workspacePath) {
+        setSelectedId(active.id)
+        return
+      }
+      unarchiveProject(active.cwd)
+      selectWorkspace(active.cwd, active.id)
+      return
+    }
+    if (!thread.sessionPath) return
+    const sessionPath = thread.sessionPath
+    if (thread.cwd !== workspacePath) {
+      unarchiveProject(thread.cwd)
+      selectWorkspace(thread.cwd)
+    }
+    await startWorkspaceSession(() => openSession(thread.cwd, sessionPath))
+  }, [
+    selectWorkspace,
+    sessions,
+    setSelectedId,
+    startWorkspaceSession,
+    unarchiveProject,
+    workspacePath,
+  ])
+
+  /** Creates a new thread in an explicit project, switching to it first when it is not active. */
+  const createThreadInProject = useCallback(async (projectPath: string): Promise<void> => {
+    if (projectPath !== workspacePath) selectProject(projectPath)
+    await startWorkspaceSession(() => createSession(projectPath))
+  }, [selectProject, startWorkspaceSession, workspacePath])
+
+  const loadCapabilities = useCallback(() => listCapabilities(workspacePath), [workspacePath])
+
+  const openCapabilityFolder = useCallback((path: string) => {
+    void openExplorer(path).catch((cause) => showToast('error', messageOf(cause)))
+  }, [showToast])
+
   const updateRightSidebarWidth = useCallback((width: number) => {
     const nextWidth = clampRightSidebarWidth(width)
     window.localStorage.setItem('pi-livecraft.right-sidebar-width', String(nextWidth))
@@ -525,7 +640,7 @@ function App() {
       if (event.type === 'session_info_changed') {
         const name = typeof event.name === 'string' && event.name.trim()
           ? event.name.trim()
-          : 'New session'
+          : unnamedSessionName
         renameSession(sessionId, name)
       }
       if (event.type === 'agent_start') updateSession(sessionId, { status: 'running' })
@@ -709,7 +824,7 @@ function App() {
       try {
         await sendPiCommand(selectedId, command)
         const sentSession = sessions.find((session) => session.id === selectedId)
-        const shouldNameSession = !isCommand && sentSession?.name === 'Nouvelle session'
+        const shouldNameSession = !isCommand && sentSession?.name === unnamedSessionName
           && !snapshot
             .messages
             .some((entry) => entry.role === 'user')
@@ -968,6 +1083,18 @@ function App() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [commandPaletteOpen, dialog, executeCommand, settingsOpen, shortcuts])
 
+  // Sidebar collapse toggle (⌘B / Ctrl+B), independent of the remappable command shortcuts.
+  useEffect(() => {
+    const handleToggleSidebar = (event: KeyboardEvent): void => {
+      if (event.defaultPrevented || event.altKey || event.shiftKey) return
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'b') return
+      event.preventDefault()
+      toggleSidebarCollapsed()
+    }
+    window.addEventListener('keydown', handleToggleSidebar)
+    return () => window.removeEventListener('keydown', handleToggleSidebar)
+  }, [toggleSidebarCollapsed])
+
   /** Positions the conversation on the element chosen from session analysis. */
   const navigateToAnalysisTarget = useCallback((target: SessionAnalysisTarget): void => {
     if (target.kind === 'tool' || target.kind === 'turn') {
@@ -1028,33 +1155,33 @@ function App() {
     <div
       className={`app-shell ${
         rightPanelVisible ? 'right-sidebar-visible' : 'right-sidebar-collapsed'
-      }`}
+      }${sidebarCollapsed ? ' sidebar-collapsed' : ''}`}
       style={{
         '--right-sidebar-width': `${rightSidebarWidth}px`,
-        '--workspace-sidebar-width': `${workspaceSidebarWidth}px`,
+        '--workspace-sidebar-width': sidebarCollapsed ? '52px' : `${workspaceSidebarWidth}px`,
       } as CSSProperties}
     >
       <WorkspaceSidebar
+        collapsed={sidebarCollapsed}
         compactingSessionIds={compactingSessionIds}
         completedSessionIds={completedSessionIds}
         isRefreshing={isRefreshingSessions}
-        recentSessions={recentSessions}
-        sentSessions={sentSessions}
+        projects={projects}
         sessions={sessions}
         selectedId={selectedId}
         width={workspaceSidebarWidth}
-        workspacePath={workspacePath}
-        onChooseWorkspace={() => setDirectoryPickerOpen(true)}
-        onCreate={async () => {
-          await startAndSelectSession(() => createSession(workspacePath))
-        }}
-        onOpenSession={async (recentSession) => {
-          await startAndSelectSession(() => openSession(workspacePath, recentSession.sessionPath))
-        }}
-        onSelectOtherWorkspaceSession={(session) => selectWorkspace(session.cwd, session.id)}
-        onSelectSession={setSelectedId}
-        onError={(cause) => showToast('error', messageOf(cause))}
+        activeWorkspacePath={workspacePath}
+        archivedProjects={archivedProjects}
+        onToggleCollapsed={toggleSidebarCollapsed}
+        onChooseProject={() => setDirectoryPickerOpen(true)}
+        onCreateThread={createThreadInProject}
+        onActivateThread={activateThread}
+        onTogglePin={togglePinnedProject}
+        onArchiveProject={archiveProject}
+        onUnarchiveProject={unarchiveProject}
+        onOpenProjectFolder={openCapabilityFolder}
         onOpenSettings={() => setSettingsOpen(true)}
+        onError={(cause) => showToast('error', messageOf(cause))}
         onResize={updateWorkspaceSidebarWidth}
       />
 
@@ -1286,7 +1413,7 @@ function App() {
           recentPaths={recentWorkspacePaths}
           onClose={() => setDirectoryPickerOpen(false)}
           onError={(cause) => showToast('error', messageOf(cause))}
-          onSelect={selectWorkspace}
+          onSelect={selectProject}
         />
       )}
       {questionnaire && !questionnaireInComposer && (
@@ -1324,6 +1451,9 @@ function App() {
           terminalCommand={terminalCommand}
           themes={allThemes(themePreferences)}
           activeThemeId={activeTheme.id}
+          workspacePath={workspacePath}
+          onLoadCapabilities={loadCapabilities}
+          onOpenCapabilityFolder={openCapabilityFolder}
           onChange={(id, shortcut) => {
             const next = { ...shortcuts, [id]: shortcut }
             setShortcuts(next)
@@ -1370,6 +1500,27 @@ function readShortcuts(): Partial<Record<CommandId, string>> {
     >
   } catch {
     return defaultShortcuts
+  }
+}
+
+/** Reads a persisted list of canonical project paths, tolerating absent or corrupt storage. */
+function readProjectPaths(key: string): string[] {
+  try {
+    const value: unknown = JSON.parse(window.localStorage.getItem(key) ?? '[]')
+    return Array.isArray(value)
+      ? value.filter((path): path is string => typeof path === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+/** Persists a list of canonical project paths. */
+function writeProjectPaths(key: string, paths: readonly string[]): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify([...paths]))
+  } catch {
+    // localStorage may be unavailable
   }
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  CapabilityInventory,
   DirectoryListing,
   GitFileDiff,
   GitPushResult,
@@ -76,6 +77,10 @@ export async function listRecentSessions(cwd: string): Promise<RecentSession[]> 
 
 export async function listDirectories(path: string): Promise<DirectoryListing> {
   return request<DirectoryListing>(`/api/directories?path=${encodeURIComponent(path)}`)
+}
+
+export async function listCapabilities(cwd: string): Promise<CapabilityInventory> {
+  return request<CapabilityInventory>(`/api/capabilities?cwd=${encodeURIComponent(cwd)}`)
 }
 
 export async function openExplorer(cwd: string): Promise<void> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -79,6 +79,13 @@ export async function listDirectories(path: string): Promise<DirectoryListing> {
   return request<DirectoryListing>(`/api/directories?path=${encodeURIComponent(path)}`)
 }
 
+export async function pickDirectory(initialPath: string): Promise<{ path: string | null }> {
+  return request<{ path: string | null }>('/api/directories/pick', {
+    method: 'POST',
+    body: JSON.stringify({ path: initialPath }),
+  })
+}
+
 export async function listCapabilities(cwd: string): Promise<CapabilityInventory> {
   return request<CapabilityInventory>(`/api/capabilities?cwd=${encodeURIComponent(cwd)}`)
 }

--- a/src/features/composer/prompt-title.ts
+++ b/src/features/composer/prompt-title.ts
@@ -1,4 +1,8 @@
-import { defaultWorkerName, isGenericSessionName } from '../../../shared/session-names.ts'
+import {
+  defaultWorkerName,
+  isGenericSessionName,
+  unnamedSessionName,
+} from '../../../shared/session-names.ts'
 
 const maxSessionTitleLength = 90
 const separator = ' — '
@@ -31,4 +35,18 @@ export function displayThreadTitle(rawName: string | undefined, worker?: string)
   const selfPrefix = `${workerName}${separator}`
   if (context.startsWith(selfPrefix)) context = context.slice(selfPrefix.length).trim()
   return composeThreadTitle(workerName, context)
+}
+
+/**
+ * Thread title as plain context: worker prefixes (current worker or the generic default) are
+ * stripped and never re-composed — worker identity lives in the row's meta line instead.
+ */
+export function threadContextTitle(rawName: string | undefined, worker?: string): string {
+  const workerName = (worker ?? '').trim() || defaultWorkerName
+  let context = (rawName ?? '').trim()
+  for (const prefix of [`${workerName}${separator}`, `${defaultWorkerName}${separator}`]) {
+    if (context.startsWith(prefix)) context = context.slice(prefix.length).trim()
+  }
+  if (isGenericSessionName(context)) context = ''
+  return context || unnamedSessionName
 }

--- a/src/features/composer/prompt-title.ts
+++ b/src/features/composer/prompt-title.ts
@@ -1,9 +1,34 @@
-const maxSessionTitleLength = 90
+import { defaultWorkerName, isGenericSessionName } from '../../../shared/session-names.ts'
 
-/** Builds an immediate fallback title while leaving later extension-generated titles free to replace it. */
+const maxSessionTitleLength = 90
+const separator = ' — '
+
+/** Builds an immediate fallback context while leaving later extension-generated titles free to replace it. */
 export function promptSessionTitle(prompt: string): string {
   const normalized = prompt.replace(/\s+/g, ' ').trim()
   return normalized.length > maxSessionTitleLength
     ? `${normalized.slice(0, maxSessionTitleLength - 1)}…`
     : normalized
+}
+
+/** Joins a worker label and a short context into the canonical `<worker> — <context>` thread title. */
+export function composeThreadTitle(worker: string, context: string): string {
+  const workerName = worker.trim() || defaultWorkerName
+  const trimmedContext = context.trim()
+  return trimmedContext ? `${workerName}${separator}${trimmedContext}` : workerName
+}
+
+/**
+ * Formats the title shown for a thread. Stored session names are always plain context (the first
+ * prompt or a Pi-generated title), so the current worker is composed in at render time — which
+ * preserves the worker prefix across later Pi renames and guarantees a non-blank, non-generic
+ * result. The exact current-worker self-prefix is stripped first so re-composition is idempotent.
+ */
+export function displayThreadTitle(rawName: string | undefined, worker?: string): string {
+  const workerName = (worker ?? '').trim() || defaultWorkerName
+  let context = (rawName ?? '').trim()
+  if (isGenericSessionName(context)) context = ''
+  const selfPrefix = `${workerName}${separator}`
+  if (context.startsWith(selfPrefix)) context = context.slice(selfPrefix.length).trim()
+  return composeThreadTitle(workerName, context)
 }

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
 import * as Select from '@radix-ui/react-select'
+import type { CapabilityEntry, CapabilityInventory } from '../../../shared/types.ts'
 import type { CommandDefinition, CommandId } from '../commands/command-registry.ts'
 import { shortcutFromEvent, shortcutConflicts } from '../commands/command-registry.ts'
 import {
@@ -25,7 +26,7 @@ const themeVariableLabels: Record<ThemeVariable, string> = {
 // ── Tab registry ───────────────────────────────────────────────────
 
 /** Identifies a settings tab. Extend this union when adding a new tab. */
-export type SettingsTabId = 'themes' | 'terminal' | 'shortcuts'
+export type SettingsTabId = 'themes' | 'terminal' | 'shortcuts' | 'skills' | 'extensions'
 
 /** Describes one tab in the settings modal. */
 export interface SettingsTabDefinition {
@@ -36,6 +37,8 @@ export interface SettingsTabDefinition {
 /** Ordered list of tabs rendered in the settings modal. */
 export const settingsTabs: SettingsTabDefinition[] = [
   { id: 'themes', label: 'Color themes' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'extensions', label: 'Extensions' },
   { id: 'terminal', label: 'Terminal' },
   { id: 'shortcuts', label: 'Shortcuts' },
 ]
@@ -48,6 +51,9 @@ interface SettingsPanelProps {
   terminalCommand: string
   themes: Theme[]
   activeThemeId: string
+  workspacePath: string
+  onLoadCapabilities: () => Promise<CapabilityInventory>
+  onOpenCapabilityFolder: (path: string) => void
   onChange: (id: CommandId, shortcut: string) => void
   onTerminalCommandChange: (value: string) => void
   onSelectTheme: (id: string) => void
@@ -317,6 +323,122 @@ function ShortcutsSettings(
   )
 }
 
+interface CapabilityListProps {
+  kind: 'skill' | 'extension'
+  entries: CapabilityEntry[]
+  surfaceError: string
+  loading: boolean
+  onRefresh: () => void
+  onOpenFolder: (path: string) => void
+}
+
+/** Renders one skill or extension entry with its scope, capabilities, and a safe open-folder action. */
+function CapabilityItem(
+  { entry, onOpenFolder }: { entry: CapabilityEntry; onOpenFolder: (path: string) => void },
+) {
+  return (
+    <li className='capability-item'>
+      <div className='capability-item-head'>
+        <strong>{entry.name}</strong>
+        <span className={`capability-badge ${entry.enabled ? 'enabled' : 'disabled'}`}>
+          {entry.enabled ? 'Enabled' : 'Disabled'}
+        </span>
+      </div>
+      {entry.description && <p className='capability-desc'>{entry.description}</p>}
+      <dl className='capability-meta'>
+        <div>
+          <dt>Scope</dt>
+          <dd>{entry.scope} · {entry.origin}</dd>
+        </div>
+        {entry.commands && entry.commands.length > 0 && (
+          <div>
+            <dt>Commands</dt>
+            <dd>{entry.commands.join(', ')}</dd>
+          </div>
+        )}
+        {typeof entry.toolCount === 'number' && (
+          <div>
+            <dt>Tools</dt>
+            <dd>{entry.toolCount}</dd>
+          </div>
+        )}
+        <div className='capability-path'>
+          <dt>Path</dt>
+          <dd>{entry.path}</dd>
+        </div>
+      </dl>
+      <button className='capability-open' onClick={() => onOpenFolder(entry.path)} type='button'>
+        Open folder
+      </button>
+    </li>
+  )
+}
+
+/** Lists installed Pi skills or extensions with truthful loading, error, and empty states. */
+function CapabilityList(
+  { kind, entries, surfaceError, loading, onRefresh, onOpenFolder }: CapabilityListProps,
+) {
+  const [search, setSearch] = useState('')
+  const query = search.trim().toLowerCase()
+  const filtered = entries.filter((entry) =>
+    query.length === 0
+    || entry.name.toLowerCase().includes(query)
+    || (entry.description ?? '').toLowerCase().includes(query)
+    || entry.scope.includes(query)
+  )
+  const noun = kind === 'skill' ? 'skills' : 'extensions'
+
+  function renderBody(): ReactNode {
+    if (surfaceError) {
+      return (
+        <p className='capability-error' role='alert'>
+          Could not read {noun}: {surfaceError}
+        </p>
+      )
+    }
+    if (loading && entries.length === 0) {
+      return <p className='capability-status' role='status'>Loading {noun}…</p>
+    }
+    if (filtered.length === 0) {
+      return (
+        <p className='capability-empty'>
+          {entries.length === 0 ? `No ${noun} installed.` : `No ${noun} match “${search}”.`}
+        </p>
+      )
+    }
+    return (
+      <ul className='capability-items'>
+        {filtered.map((entry) => (
+          <CapabilityItem
+            entry={entry}
+            key={`${entry.scope}:${entry.path}`}
+            onOpenFolder={onOpenFolder}
+          />
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <section className='capability-settings'>
+      <div className='capability-toolbar'>
+        <input
+          aria-label={`Search ${noun}`}
+          className='capability-search'
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={`Search ${noun}…`}
+          spellCheck={false}
+          value={search}
+        />
+        <button className='capability-refresh' disabled={loading} onClick={onRefresh} type='button'>
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </div>
+      {renderBody()}
+    </section>
+  )
+}
+
 // ── Main panel ─────────────────────────────────────────────────────
 
 /** Configures local shortcuts, terminal behavior, and editable color themes. */
@@ -326,6 +448,9 @@ export function SettingsPanel({
   terminalCommand,
   themes,
   activeThemeId,
+  workspacePath,
+  onLoadCapabilities,
+  onOpenCapabilityFolder,
   onChange,
   onTerminalCommandChange,
   onSelectTheme,
@@ -340,6 +465,9 @@ export function SettingsPanel({
   const [activeTab, setActiveTab] = useState<SettingsTabId>('themes')
   const [capturing, setCapturing] = useState<CommandId | null>(null)
   const [themeName, setThemeName] = useState('')
+  const [inventory, setInventory] = useState<CapabilityInventory | null>(null)
+  const [capabilitiesLoading, setCapabilitiesLoading] = useState(false)
+  const [capabilitiesError, setCapabilitiesError] = useState('')
   const conflicts = shortcutConflicts(shortcuts)
   const activeTheme = themes.find((theme) => theme.id === activeThemeId) ?? themes[0]
   const editableTheme = Boolean(activeTheme)
@@ -347,6 +475,29 @@ export function SettingsPanel({
   useEffect(() => {
     setThemeName(activeTheme?.name ?? '')
   }, [activeTheme?.id, activeTheme?.name])
+
+  const loadCapabilities = useCallback(() => {
+    setCapabilitiesLoading(true)
+    setCapabilitiesError('')
+    onLoadCapabilities()
+      .then(setInventory)
+      .catch((cause) =>
+        setCapabilitiesError(cause instanceof Error ? cause.message : String(cause))
+      )
+      .finally(() => setCapabilitiesLoading(false))
+  }, [onLoadCapabilities])
+
+  // Reload the inventory when the picker points at a different project.
+  useEffect(() => {
+    setInventory(null)
+    setCapabilitiesError('')
+  }, [workspacePath])
+
+  const capabilitiesNeeded = activeTab === 'skills' || activeTab === 'extensions'
+  useEffect(() => {
+    if (capabilitiesNeeded && inventory === null && !capabilitiesLoading && !capabilitiesError)
+      loadCapabilities()
+  }, [capabilitiesNeeded, capabilitiesError, capabilitiesLoading, inventory, loadCapabilities])
 
   const commitThemeName = () => {
     if (activeTheme && themeName.trim() !== activeTheme.name)
@@ -398,6 +549,37 @@ export function SettingsPanel({
                 onUpdateThemeColor={onUpdateThemeColor}
                 themeName={themeName}
                 themes={themes}
+              />
+            </TabPanel>
+          )}
+          {activeTab === 'skills' && (
+            <TabPanel key='skills' id='settings-tab-skills' labelledBy='settings-tab-btn-skills'>
+              <CapabilityList
+                entries={inventory
+                  ?.skills ?? []}
+                kind='skill'
+                loading={capabilitiesLoading}
+                onOpenFolder={onOpenCapabilityFolder}
+                onRefresh={loadCapabilities}
+                surfaceError={capabilitiesError || inventory
+                  ?.skillsError
+                  || ''}
+              />
+            </TabPanel>
+          )}
+          {activeTab === 'extensions' && (
+            <TabPanel
+              key='extensions'
+              id='settings-tab-extensions'
+              labelledBy='settings-tab-btn-extensions'
+            >
+              <CapabilityList
+                entries={inventory?.extensions ?? []}
+                kind='extension'
+                loading={capabilitiesLoading}
+                onOpenFolder={onOpenCapabilityFolder}
+                onRefresh={loadCapabilities}
+                surfaceError={capabilitiesError || inventory?.extensionsError || ''}
               />
             </TabPanel>
           )}

--- a/src/features/settings/settings.css
+++ b/src/features/settings/settings.css
@@ -424,3 +424,158 @@
     width: 100%;
   }
 }
+
+/* ── Skills & extensions inventory ──────────────────────────────────── */
+.capability-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.capability-toolbar {
+  display: flex;
+  gap: 8px;
+}
+.capability-search {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  padding: 8px 11px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  font-size: 13px;
+}
+.capability-search:focus {
+  outline: 0;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.capability-refresh {
+  flex: 0 0 auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  padding: 8px 14px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 13px;
+}
+.capability-refresh:hover:not(:disabled), .capability-refresh:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  outline: 0;
+}
+.capability-refresh:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.capability-status, .capability-empty {
+  padding: 18px 4px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+.capability-error {
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--danger) 40%, var(--line));
+  border-radius: 9px;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--danger) 10%, var(--surface-raised));
+  color: var(--danger);
+  font-size: 13px;
+}
+.capability-items {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.capability-item {
+  display: grid;
+  gap: 6px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 12px 14px;
+  background: var(--surface-raised);
+}
+.capability-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.capability-item-head strong {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.capability-badge {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.capability-badge.enabled {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent-hover);
+}
+.capability-badge.disabled {
+  background: color-mix(in srgb, var(--muted) 18%, transparent);
+  color: var(--muted);
+}
+.capability-desc {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.capability-meta {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+.capability-meta > div {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+}
+.capability-meta dt {
+  flex: 0 0 66px;
+  color: var(--muted);
+  font-weight: 600;
+}
+.capability-meta dd {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+.capability-meta .capability-path dd {
+  font: 11px ui-monospace, monospace;
+  color: var(--muted);
+}
+.capability-open {
+  justify-self: start;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  padding: 6px 12px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 12px;
+}
+.capability-open:hover, .capability-open:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  outline: 0;
+}

--- a/src/features/workspace/DirectoryPicker.tsx
+++ b/src/features/workspace/DirectoryPicker.tsx
@@ -1,24 +1,8 @@
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from 'react'
-import { listDirectories } from '../../api.ts'
-import { directoryCompletionTarget } from './directory-completion.ts'
+import { useState } from 'react'
+import { pickDirectory } from '../../api.ts'
 import { projectLabel } from './sidebar-projects.ts'
 
-/**
- * Explicit project/workspace picker: completes and validates a local path, and lists registered
- * recent projects and local worktrees for selection. Project identity is always the canonical path
- * returned by `listDirectories`, never the display label.
- *
- * Directory suggestions use a version counter: each keystroke increments
- * `completionVersionRef`, and only the latest request's result is applied.
- * This prevents a slow `listDirectories()` response from overwriting
- * newer suggestions for the path currently being typed.
- */
+/** Chooses a local project folder or reopens one of the recent project roots. */
 export function DirectoryPicker({ initialPath, recentPaths, onClose, onError, onSelect }: {
   initialPath: string
   recentPaths: string[]
@@ -26,83 +10,18 @@ export function DirectoryPicker({ initialPath, recentPaths, onClose, onError, on
   onError: (cause: unknown) => void
   onSelect: (path: string) => void
 }) {
-  const [path, setPath] = useState(initialPath)
-  const [suggestions, setSuggestions] = useState<string[]>([])
-  const [activeSuggestion, setActiveSuggestion] = useState(-1)
-  const completionVersionRef = useRef(0)
+  const [openingFolder, setOpeningFolder] = useState(false)
+  const visibleRecentPaths = recentPaths.filter((recentPath) => recentPath !== initialPath)
 
-  // Stale requests must not replace suggestions for the path currently being entered.
-  useEffect(() => {
-    const version = ++completionVersionRef.current
-    const target = directoryCompletionTarget(path)
-    if (!target) {
-      setSuggestions([])
-      return
-    }
-
-    void listDirectories(target.parentPath)
-      .then((parent) => {
-        if (version !== completionVersionRef.current) return
-        setSuggestions(
-          parent
-            .directories
-            .filter((directory) => directory.name.startsWith(target.namePrefix))
-            .map((directory) => `${target.pathPrefix}${directory.name}`)
-            .filter((suggestion) => suggestion !== initialPath),
-        )
-        setActiveSuggestion(-1)
-      })
-      .catch(() => {
-        if (version === completionVersionRef.current) setSuggestions([])
-      })
-  }, [path])
-
-  const query = path.trim().toLowerCase()
-  const visibleRecentPaths = useMemo(
-    () =>
-      recentPaths
-        .filter((recentPath) => recentPath !== initialPath)
-        .filter((recentPath) =>
-          query.length === 0
-          || recentPath.toLowerCase().includes(query)
-          || projectLabel(recentPath).toLowerCase().includes(query)
-        ),
-    [initialPath, query, recentPaths],
-  )
-
-  /** Verifies that the path is still accessible before adopting it as the workspace. */
-  function selectDirectory(nextPath: string): void {
-    void listDirectories(nextPath).then((directory) => onSelect(directory.path)).catch(onError)
-  }
-
-  /** Applies standard completion-list shortcuts without intercepting normal input. */
-  function handlePathKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): void {
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      onClose()
-      return
-    }
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      if (suggestions.length === 0) return
-      event.preventDefault()
-      setActiveSuggestion((current) =>
-        event.key === 'ArrowDown'
-          ? Math.min(current + 1, suggestions.length - 1)
-          : Math.max(current - 1, 0)
-      )
-      return
-    }
-    if (event.key === 'Tab') {
-      const suggestion = suggestions[activeSuggestion >= 0 ? activeSuggestion : 0]
-      if (!suggestion) return
-      event.preventDefault()
-      setPath(suggestion)
-      setActiveSuggestion(-1)
-      return
-    }
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      selectDirectory(path)
+  async function openFolder(): Promise<void> {
+    setOpeningFolder(true)
+    try {
+      const result = await pickDirectory(initialPath)
+      if (result.path) onSelect(result.path)
+    } catch (cause) {
+      onError(cause)
+    } finally {
+      setOpeningFolder(false)
     }
   }
 
@@ -114,86 +33,67 @@ export function DirectoryPicker({ initialPath, recentPaths, onClose, onError, on
         className='modal directory-picker'
         role='dialog'
       >
-        <h2 id='directory-picker-title'>Switch project</h2>
+        <h2 id='directory-picker-title'>Open project</h2>
         <div className='project-picker-current'>
           <span>Current project</span>
           <strong>{projectLabel(initialPath)}</strong>
           <small>{initialPath}</small>
         </div>
-        <label className='directory-path-label' htmlFor='directory-path'>
-          Project path or search
-        </label>
-        <input
-          aria-activedescendant={activeSuggestion >= 0
-            ? `directory-suggestion-${activeSuggestion}`
-            : undefined}
-          autoComplete='off'
-          autoFocus
-          aria-autocomplete='list'
-          aria-controls={suggestions.length > 0 ? 'directory-suggestions' : undefined}
-          aria-expanded={suggestions.length > 0}
-          className='directory-path-input'
-          id='directory-path'
-          onChange={(event) => setPath(event.target.value)}
-          onKeyDown={handlePathKeyDown}
-          placeholder='~/projects or /absolute/path'
-          role='combobox'
-          value={path}
-        />
-        <p className='directory-path-hint'>
-          Tab completes · ↑↓ navigate · Enter selects · Escape cancels
+        <p className='directory-picker-intro'>
+          Choose a folder from your computer, or reopen a recent project.
         </p>
-        {suggestions.length > 0 && (
-          <div
-            aria-label='Directory suggestions'
-            className='directory-suggestions'
-            id='directory-suggestions'
-            role='listbox'
-          >
-            {suggestions.map((suggestion, index) => (
-              <div
-                aria-selected={index === activeSuggestion}
-                className={index === activeSuggestion ? 'active' : undefined}
-                id={`directory-suggestion-${index}`}
-                key={suggestion}
-                onClick={() => {
-                  setPath(suggestion)
-                  setActiveSuggestion(-1)
-                }}
-                onMouseDown={(event) => event.preventDefault()}
-                role='option'
-              >
-                {suggestion}
-              </div>
-            ))}
-          </div>
-        )}
-        {visibleRecentPaths.length > 0 && (
-          <section aria-label='Projects' className='recent-workspaces'>
-            <strong>Projects</strong>
-            <div>
-              {visibleRecentPaths
-                .map((recentPath) => (
+        <button
+          aria-busy={openingFolder}
+          className='directory-picker-open primary'
+          disabled={openingFolder}
+          onClick={() => void openFolder()}
+          type='button'
+        >
+          <FolderIcon />
+          {openingFolder ? 'Opening…' : 'Open folder…'}
+        </button>
+        {visibleRecentPaths.length > 0
+          ? (
+            <section aria-label='Recent projects' className='recent-workspaces'>
+              <strong>Recent projects</strong>
+              <div>
+                {visibleRecentPaths.map((recentPath) => (
                   <button
                     className='project-picker-option'
                     key={recentPath}
-                    onClick={() => selectDirectory(recentPath)}
+                    onClick={() => onSelect(recentPath)}
                     type='button'
                   >
                     <span className='project-picker-option-label'>{projectLabel(recentPath)}</span>
                     <span className='project-picker-option-path'>{recentPath}</span>
                   </button>
                 ))}
-            </div>
-          </section>
-        )}
+              </div>
+            </section>
+          )
+          : <p className='directory-picker-empty'>No recent projects yet.</p>}
         <div className='modal-actions'>
           <button onClick={onClose} type='button'>Cancel</button>
-          <button className='primary' onClick={() => selectDirectory(path)} type='button'>
-            Open
-          </button>
         </div>
       </section>
     </div>
+  )
+}
+
+function FolderIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='none'
+      height='16'
+      stroke='currentColor'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='1.7'
+      viewBox='0 0 24 24'
+      width='16'
+    >
+      <path d='M3.5 6.5A1.5 1.5 0 0 1 5 5h4l2 2h8A1.5 1.5 0 0 1 20.5 8.5v9A1.5 1.5 0 0 1 19 19H5a1.5 1.5 0 0 1-1.5-1.5v-11Z' />
+    </svg>
   )
 }

--- a/src/features/workspace/DirectoryPicker.tsx
+++ b/src/features/workspace/DirectoryPicker.tsx
@@ -1,9 +1,18 @@
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 import { listDirectories } from '../../api.ts'
 import { directoryCompletionTarget } from './directory-completion.ts'
+import { projectLabel } from './sidebar-projects.ts'
 
 /**
- * Completes and validates a local path before changing the workspace.
+ * Explicit project/workspace picker: completes and validates a local path, and lists registered
+ * recent projects and local worktrees for selection. Project identity is always the canonical path
+ * returned by `listDirectories`, never the display label.
  *
  * Directory suggestions use a version counter: each keystroke increments
  * `completionVersionRef`, and only the latest request's result is applied.
@@ -48,7 +57,18 @@ export function DirectoryPicker({ initialPath, recentPaths, onClose, onError, on
       })
   }, [path])
 
-  const visibleRecentPaths = recentPaths.filter((recentPath) => recentPath !== initialPath)
+  const query = path.trim().toLowerCase()
+  const visibleRecentPaths = useMemo(
+    () =>
+      recentPaths
+        .filter((recentPath) => recentPath !== initialPath)
+        .filter((recentPath) =>
+          query.length === 0
+          || recentPath.toLowerCase().includes(query)
+          || projectLabel(recentPath).toLowerCase().includes(query)
+        ),
+    [initialPath, query, recentPaths],
+  )
 
   /** Verifies that the path is still accessible before adopting it as the workspace. */
   function selectDirectory(nextPath: string): void {
@@ -94,8 +114,15 @@ export function DirectoryPicker({ initialPath, recentPaths, onClose, onError, on
         className='modal directory-picker'
         role='dialog'
       >
-        <h2 id='directory-picker-title'>Choose a directory</h2>
-        <label className='directory-path-label' htmlFor='directory-path'>Directory path</label>
+        <h2 id='directory-picker-title'>Switch project</h2>
+        <div className='project-picker-current'>
+          <span>Current project</span>
+          <strong>{projectLabel(initialPath)}</strong>
+          <small>{initialPath}</small>
+        </div>
+        <label className='directory-path-label' htmlFor='directory-path'>
+          Project path or search
+        </label>
         <input
           aria-activedescendant={activeSuggestion >= 0
             ? `directory-suggestion-${activeSuggestion}`
@@ -142,17 +169,19 @@ export function DirectoryPicker({ initialPath, recentPaths, onClose, onError, on
           </div>
         )}
         {visibleRecentPaths.length > 0 && (
-          <section aria-label='Recent workspaces' className='recent-workspaces'>
-            <strong>Recent workspaces</strong>
+          <section aria-label='Projects' className='recent-workspaces'>
+            <strong>Projects</strong>
             <div>
               {visibleRecentPaths
                 .map((recentPath) => (
                   <button
+                    className='project-picker-option'
                     key={recentPath}
                     onClick={() => selectDirectory(recentPath)}
                     type='button'
                   >
-                    {recentPath}
+                    <span className='project-picker-option-label'>{projectLabel(recentPath)}</span>
+                    <span className='project-picker-option-path'>{recentPath}</span>
                   </button>
                 ))}
             </div>

--- a/src/features/workspace/WorkspaceSidebar.tsx
+++ b/src/features/workspace/WorkspaceSidebar.tsx
@@ -7,12 +7,12 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react'
 import { Tooltip } from '../../components/Tooltip.tsx'
-import type { SessionSummary } from '../../../shared/types.ts'
+import type { SessionModel, SessionSummary } from '../../../shared/types.ts'
 import { defaultWorkerName } from '../../../shared/session-names.ts'
-import { displayThreadTitle } from '../composer/prompt-title.ts'
+import { threadContextTitle } from '../composer/prompt-title.ts'
 import { sessionIndicator, type SessionIndicator } from './session-indicator.ts'
 import { SessionStatusIndicator } from './SessionStatusIndicator.tsx'
-import type { ProjectGroup, ProjectThread } from './sidebar-projects.ts'
+import { projectLabel, type ProjectGroup, type ProjectThread } from './sidebar-projects.ts'
 import { maxWorkspaceSidebarWidth, minWorkspaceSidebarWidth } from './workspace-sidebar.ts'
 
 interface WorkspaceSidebarProps {
@@ -24,15 +24,19 @@ interface WorkspaceSidebarProps {
   sessions: SessionSummary[]
   selectedId: string
   width: number
-  activeWorkspacePath: string
   archivedProjects: string[]
   onToggleCollapsed: () => void
   onChooseProject: () => void
   onCreateThread: (projectPath: string) => Promise<void>
   onActivateThread: (thread: ProjectThread) => Promise<void>
-  onTogglePin: (projectPath: string) => void
+  onReorderProject: (draggedPath: string, targetPath: string) => void
   onArchiveProject: (projectPath: string) => void
   onUnarchiveProject: (projectPath: string) => void
+  onTogglePinSession: (sessionKey: string) => void
+  onArchiveSession: (sessionKey: string) => void
+  onUnarchiveSession: (sessionKey: string) => void
+  collapsedProjects: string[]
+  onToggleCollapsedProject: (projectPath: string) => void
   onOpenProjectFolder: (projectPath: string) => void
   onOpenSettings: () => void
   onResize: (width: number) => void
@@ -49,15 +53,19 @@ export function WorkspaceSidebar({
   sessions,
   selectedId,
   width,
-  activeWorkspacePath,
   archivedProjects,
   onToggleCollapsed,
   onChooseProject,
   onCreateThread,
   onActivateThread,
-  onTogglePin,
+  onReorderProject,
   onArchiveProject,
   onUnarchiveProject,
+  onTogglePinSession,
+  onArchiveSession,
+  onUnarchiveSession,
+  collapsedProjects,
+  onToggleCollapsedProject,
   onOpenProjectFolder,
   onOpenSettings,
   onResize,
@@ -66,6 +74,14 @@ export function WorkspaceSidebar({
   const selectedThreadRef = useRef<HTMLButtonElement>(null)
   const totalThreads = useMemo(
     () => projects.reduce((count, project) => count + project.threads.length, 0),
+    [projects],
+  )
+  const visibleProjects = useMemo(
+    () => projects.filter((project) => project.threads.length > 0 || project.isActiveWorkspace),
+    [projects],
+  )
+  const archivedThreads = useMemo(
+    () => projects.flatMap((project) => project.archivedThreads ?? []),
     [projects],
   )
 
@@ -124,26 +140,28 @@ export function WorkspaceSidebar({
             π
           </button>
         </Tooltip>
-        <Tooltip label='New thread'>
-          <button
-            aria-label='New thread'
-            className='sidebar-rail-button'
-            onClick={() => void onCreateThread(activeWorkspacePath).catch(onError)}
-            type='button'
-          >
-            <PlusIcon />
-          </button>
-        </Tooltip>
-        <Tooltip label='Settings'>
-          <button
-            aria-label='Open settings'
-            className='sidebar-rail-button'
-            onClick={onOpenSettings}
-            type='button'
-          >
-            <SettingsIcon />
-          </button>
-        </Tooltip>
+        <div className='sidebar-rail-actions'>
+          <Tooltip label='Browse or add project'>
+            <button
+              aria-label='Browse or add project'
+              className='sidebar-rail-button'
+              onClick={onChooseProject}
+              type='button'
+            >
+              <WorkspaceIcon />
+            </button>
+          </Tooltip>
+          <Tooltip label='Settings'>
+            <button
+              aria-label='Open settings'
+              className='sidebar-rail-button'
+              onClick={onOpenSettings}
+              type='button'
+            >
+              <SettingsIcon />
+            </button>
+          </Tooltip>
+        </div>
       </aside>
     )
   }
@@ -178,6 +196,16 @@ export function WorkspaceSidebar({
           <strong>Pi Livecraft</strong>
           <small>Project sessions</small>
         </div>
+        <Tooltip label='Browse or add project'>
+          <button
+            aria-label='Browse or add project'
+            className='settings-button project-picker-button'
+            onClick={onChooseProject}
+            type='button'
+          >
+            <WorkspaceIcon />
+          </button>
+        </Tooltip>
         <Tooltip label='Settings'>
           <button
             aria-label='Open settings'
@@ -190,34 +218,11 @@ export function WorkspaceSidebar({
         </Tooltip>
       </div>
 
-      <div className='workspace-group'>
-        <Tooltip label={activeWorkspacePath}>
-          <button
-            aria-label={`Change project. Current: ${activeWorkspacePath}`}
-            className='workspace-path'
-            onClick={onChooseProject}
-            type='button'
-          >
-            <WorkspaceIcon />
-            <div className='workspace-path-copy'>
-              <span>Project</span>
-              <strong>{activeWorkspacePath}</strong>
-            </div>
-            <ChevronIcon />
-          </button>
-        </Tooltip>
-      </div>
-
-      <NewThreadButton
-        onCreate={() => onCreateThread(activeWorkspacePath)}
-        onError={onError}
-      />
-
       <div className='project-list' aria-label='Projects and their Pi sessions'>
         {isRefreshing && totalThreads === 0 && (
           <p className='session-list-loading' role='status'>Loading sessions…</p>
         )}
-        {projects.map((project) => (
+        {visibleProjects.map((project) => (
           <ProjectSection
             key={project.path}
             project={project}
@@ -226,18 +231,48 @@ export function WorkspaceSidebar({
             selectedThreadRef={selectedThreadRef}
             compactingSessionIds={compactingSessionIds}
             completedSessionIds={completedSessionIds}
+            isCollapsed={collapsedProjects.includes(project.path)}
+            onToggleCollapsed={onToggleCollapsedProject}
             onCreateThread={onCreateThread}
             onActivateThread={onActivateThread}
-            onTogglePin={onTogglePin}
+            onReorderProject={onReorderProject}
             onArchiveProject={onArchiveProject}
             onOpenProjectFolder={onOpenProjectFolder}
+            onTogglePinSession={onTogglePinSession}
+            onArchiveSession={onArchiveSession}
             onError={onError}
           />
         ))}
         {!isRefreshing && totalThreads === 0 && (
-          <p className='empty-sidebar'>No Pi sessions yet. Start a new thread above.</p>
+          <p className='empty-sidebar'>
+            {visibleProjects.length === 0
+              ? 'No projects yet. Add a project to get started.'
+              : 'No sessions yet. Use ＋ on a project to start its first thread.'}
+          </p>
         )}
       </div>
+
+      {archivedThreads.length > 0 && (
+        <details className='archived-projects'>
+          <summary>Archived sessions ({archivedThreads.length})</summary>
+          <ul>
+            {archivedThreads.map((thread) => (
+              <li key={thread.key}>
+                <span className='archived-project-path' title={thread.name}>
+                  {threadContextTitle(thread.name, thread.worker)} · {projectLabel(thread.cwd)}
+                </span>
+                <button
+                  aria-label={`Restore session ${thread.name}`}
+                  onClick={() => onUnarchiveSession(thread.key)}
+                  type='button'
+                >
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
 
       {archivedProjects.length > 0 && (
         <details className='archived-projects'>
@@ -245,7 +280,7 @@ export function WorkspaceSidebar({
           <ul>
             {archivedProjects.map((path) => (
               <li key={path}>
-                <span className='archived-project-path' title={path}>{path}</span>
+                <span className='archived-project-path' title={path}>{projectLabel(path)}</span>
                 <button
                   aria-label={`Restore archived project ${path}`}
                   onClick={() => onUnarchiveProject(path)}
@@ -269,11 +304,15 @@ interface ProjectSectionProps {
   selectedThreadRef: React.RefObject<HTMLButtonElement | null>
   compactingSessionIds: ReadonlySet<string>
   completedSessionIds: ReadonlySet<string>
+  isCollapsed: boolean
+  onToggleCollapsed: (projectPath: string) => void
   onCreateThread: (projectPath: string) => Promise<void>
   onActivateThread: (thread: ProjectThread) => Promise<void>
-  onTogglePin: (projectPath: string) => void
+  onReorderProject: (draggedPath: string, targetPath: string) => void
   onArchiveProject: (projectPath: string) => void
   onOpenProjectFolder: (projectPath: string) => void
+  onTogglePinSession: (sessionKey: string) => void
+  onArchiveSession: (sessionKey: string) => void
   onError: (cause: unknown) => void
 }
 
@@ -287,127 +326,143 @@ function ProjectSection({
   completedSessionIds,
   onCreateThread,
   onActivateThread,
-  onTogglePin,
+  onReorderProject,
   onArchiveProject,
   onOpenProjectFolder,
+  onTogglePinSession,
+  onArchiveSession,
+  isCollapsed,
+  onToggleCollapsed,
   onError,
 }: ProjectSectionProps) {
-  const [overflowOpen, setOverflowOpen] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
   const summary = project.activeCount > 0
     ? `${project.threads.length} threads · ${project.activeCount} active`
     : `${project.threads.length} thread${project.threads.length === 1 ? '' : 's'}`
 
   return (
-    <section className='project-section' aria-label={`Project ${project.label}`}>
-      <div className='project-divider'>
-        <div className='project-divider-copy'>
-          <Tooltip label={project.path}>
+    <section
+      aria-label={`Project ${project.label}`}
+      className={`project-section${dragOver ? ' drag-over' : ''}`}
+      onDragLeave={() => setDragOver(false)}
+      onDragOver={(event) => {
+        if (!event.dataTransfer.types.includes(projectDragType)) return
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+        setDragOver(true)
+      }}
+      onDrop={(event) => {
+        setDragOver(false)
+        const draggedPath = event.dataTransfer.getData(projectDragType)
+        if (!draggedPath) return
+        event.preventDefault()
+        onReorderProject(draggedPath, project.path)
+      }}
+    >
+      <div
+        className='project-divider'
+        draggable
+        onDragStart={(event) => {
+          event.dataTransfer.setData(projectDragType, project.path)
+          event.dataTransfer.effectAllowed = 'move'
+        }}
+      >
+        <Tooltip label={project.path}>
+          <button
+            aria-expanded={!isCollapsed}
+            aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} project ${project.label}`}
+            className='project-divider-copy project-collapse-toggle'
+            onClick={() => onToggleCollapsed(project.path)}
+            type='button'
+          >
             <h2>
-              {project.pinned && <span aria-hidden='true' className='project-pin-mark'>📌</span>}
+              <span aria-hidden='true' className='project-collapse-chevron'>
+                <ChevronIcon />
+              </span>
               {project.label}
             </h2>
-          </Tooltip>
-          <small>{summary}</small>
-        </div>
-        <div className='project-actions'>
-          <Tooltip label={`New thread in ${project.label}`}>
-            <button
-              aria-label={`New thread in ${project.label}`}
-              className='project-action'
-              onClick={() => void onCreateThread(project.path).catch(onError)}
-              type='button'
-            >
-              <PlusIcon />
-            </button>
-          </Tooltip>
-          <Tooltip label={project.pinned ? 'Unpin project' : 'Pin project'}>
-            <button
-              aria-label={project.pinned ? `Unpin ${project.label}` : `Pin ${project.label}`}
-              aria-pressed={project.pinned}
-              className='project-action'
-              onClick={() => onTogglePin(project.path)}
-              type='button'
-            >
-              <PinIcon />
-            </button>
-          </Tooltip>
-          <Tooltip label={`Archive ${project.label}`}>
-            <button
-              aria-label={`Archive ${project.label}`}
-              className='project-action'
-              onClick={() => onArchiveProject(project.path)}
-              type='button'
-            >
-              <ArchiveIcon />
-            </button>
-          </Tooltip>
-          <div className='project-overflow'>
-            <button
-              aria-expanded={overflowOpen}
-              aria-haspopup='menu'
-              aria-label={`More actions for ${project.label}`}
-              className='project-action'
-              onClick={() => setOverflowOpen((open) => !open)}
-              onBlur={(event) => {
-                if (!event.currentTarget.parentElement?.contains(event.relatedTarget as Node))
-                  setOverflowOpen(false)
-              }}
-              type='button'
-            >
-              <OverflowIcon />
-            </button>
-            {overflowOpen && (
-              <div className='project-overflow-menu' role='menu'>
-                <button
-                  className='project-overflow-item'
-                  onClick={() => {
-                    setOverflowOpen(false)
-                    onOpenProjectFolder(project.path)
-                  }}
-                  role='menuitem'
-                  type='button'
-                >
-                  Open folder
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
+            <small>{summary}</small>
+          </button>
+        </Tooltip>
+        <ProjectActions
+          project={project}
+          onCreateThread={onCreateThread}
+          onArchiveProject={onArchiveProject}
+          onOpenProjectFolder={onOpenProjectFolder}
+          onError={onError}
+        />
       </div>
 
-      <nav className='session-list project-threads' aria-label={`${project.label} sessions`}>
-        {project.threads.length === 0 && <p className='project-empty'>No threads yet.</p>}
-        {project.threads.map((thread) => {
-          const active = sessions.find((session) =>
-            (thread.sessionPath
-              ? session.sessionPath === thread.sessionPath
-              : session.id === thread.id) && session.status !== 'exited'
-          )
-          const indicator = sessionIndicator(
-            active,
-            selectedId,
-            compactingSessionIds,
-            completedSessionIds,
-          )
-          const isSelected = active?.id === selectedId
-          const worker = active?.activeAgent ?? thread.worker ?? defaultWorkerName
-          const title = displayThreadTitle(thread.name, worker)
-          return (
-            <ThreadItem
-              key={thread.key}
-              indicator={indicator}
-              isSelected={isSelected}
-              selectedThreadRef={isSelected ? selectedThreadRef : undefined}
-              thread={thread}
-              title={title}
-              onActivate={onActivateThread}
-              onError={onError}
-            />
-          )
-        })}
-      </nav>
+      {isCollapsed
+        ? null
+        : (
+          <nav className='session-list project-threads' aria-label={`${project.label} sessions`}>
+            {project.threads.length === 0 && <p className='project-empty'>No threads yet.</p>}
+            {project.threads.map((thread) => {
+              const active = sessions.find((session) =>
+                (thread.sessionPath
+                  ? session.sessionPath === thread.sessionPath
+                  : session.id === thread.id) && session.status !== 'exited'
+              )
+              const indicator = sessionIndicator(
+                active,
+                selectedId,
+                compactingSessionIds,
+                completedSessionIds,
+              )
+              const isSelected = active?.id === selectedId
+              const worker = active?.activeAgent ?? thread.worker
+              const title = threadContextTitle(thread.name, worker)
+              const meta = threadMeta(
+                worker,
+                active?.model ?? thread.model,
+                active?.thinkingLevel ?? thread.thinkingLevel,
+                active?.status,
+              )
+              return (
+                <ThreadItem
+                  key={thread.key}
+                  indicator={indicator}
+                  isSelected={isSelected}
+                  selectedThreadRef={isSelected ? selectedThreadRef : undefined}
+                  thread={thread}
+                  title={title}
+                  meta={meta}
+                  onActivate={onActivateThread}
+                  onTogglePinSession={onTogglePinSession}
+                  onArchiveSession={onArchiveSession}
+                  onError={onError}
+                />
+              )
+            })}
+          </nav>
+        )}
     </section>
   )
+}
+
+const projectDragType = 'application/x-pi-livecraft-project'
+
+const sessionStatusLabels: Record<string, string> = {
+  starting: 'Starting…',
+  running: 'Working',
+  idle: 'Idle',
+}
+
+/** One glanceable line of session identity: named agent (never the generic default), model, reasoning level, and live status. */
+function threadMeta(
+  worker: string | undefined,
+  model: SessionModel | undefined,
+  thinkingLevel: string | undefined,
+  status: string | undefined,
+): string {
+  const parts = [
+    worker !== defaultWorkerName ? worker : undefined,
+    model ? model.name ?? model.id : undefined,
+    thinkingLevel,
+    status ? sessionStatusLabels[status] : undefined,
+  ]
+  return parts.filter(Boolean).join(' · ')
 }
 
 interface ThreadItemProps {
@@ -416,64 +471,177 @@ interface ThreadItemProps {
   selectedThreadRef?: React.RefObject<HTMLButtonElement | null>
   thread: ProjectThread
   title: string
+  meta: string
   onActivate: (thread: ProjectThread) => Promise<void>
+  onTogglePinSession: (sessionKey: string) => void
+  onArchiveSession: (sessionKey: string) => void
   onError: (cause: unknown) => void
 }
 
 /** A single selectable thread; shows a transient opening state while a history thread resumes. */
 function ThreadItem(
-  { indicator, isSelected, selectedThreadRef, thread, title, onActivate, onError }: ThreadItemProps,
+  {
+    indicator,
+    isSelected,
+    selectedThreadRef,
+    thread,
+    title,
+    meta,
+    onActivate,
+    onTogglePinSession,
+    onArchiveSession,
+    onError,
+  }: ThreadItemProps,
 ) {
   const [opening, setOpening] = useState(false)
   return (
-    <Tooltip label={title}>
-      <button
-        className={`session-item${isSelected ? ' selected' : ''}${
-          indicator ? ` ${indicator}` : ''
-        }`}
-        disabled={opening}
-        onClick={() => {
-          setOpening(true)
-          void onActivate(thread).catch(onError).finally(() => setOpening(false))
-        }}
-        ref={selectedThreadRef}
-        type='button'
-      >
-        {indicator && <SessionStatusIndicator status={indicator} />}
-        <span>
-          <strong>{opening ? 'Opening…' : title}</strong>
-        </span>
-      </button>
-    </Tooltip>
+    <div className='session-row'>
+      <Tooltip label={title}>
+        <button
+          className={`session-item${isSelected ? ' selected' : ''}${
+            indicator ? ` ${indicator}` : ''
+          }`}
+          disabled={opening}
+          onClick={() => {
+            setOpening(true)
+            void onActivate(thread).catch(onError).finally(() => setOpening(false))
+          }}
+          ref={selectedThreadRef}
+          type='button'
+        >
+          {indicator && <SessionStatusIndicator status={indicator} />}
+          {thread.pinned && (
+            <span aria-hidden='true' className='session-pin-mark'>
+              <PinIcon />
+            </span>
+          )}
+          <span>
+            <strong>{opening ? 'Opening…' : title}</strong>
+            {meta && <small className='session-meta'>{meta}</small>}
+          </span>
+        </button>
+      </Tooltip>
+      <SessionActions
+        thread={thread}
+        title={title}
+        onTogglePin={onTogglePinSession}
+        onArchive={onArchiveSession}
+      />
+    </div>
   )
 }
 
-/** Prevents duplicate thread creation and reports errors to the container. */
-function NewThreadButton(
-  { onCreate, onError }: { onCreate: () => Promise<void>; onError: (cause: unknown) => void },
-) {
-  const [busy, setBusy] = useState(false)
+interface ProjectActionsProps {
+  project: ProjectGroup
+  onCreateThread: (projectPath: string) => Promise<void>
+  onArchiveProject: (projectPath: string) => void
+  onOpenProjectFolder: (projectPath: string) => void
+  onError: (cause: unknown) => void
+}
 
-  async function create(): Promise<void> {
-    setBusy(true)
-    try {
-      await onCreate()
-    } catch (cause) {
-      onError(cause)
-    } finally {
-      setBusy(false)
-    }
-  }
+function ProjectActions(
+  {
+    project,
+    onCreateThread,
+    onArchiveProject,
+    onOpenProjectFolder,
+    onError,
+  }: ProjectActionsProps,
+) {
+  const [overflowOpen, setOverflowOpen] = useState(false)
 
   return (
-    <button
-      className='new-session'
-      disabled={busy}
-      onClick={() => void create()}
-      type='button'
-    >
-      {busy ? 'Starting…' : '＋ New thread'}
-    </button>
+    <div className='project-actions'>
+      <Tooltip label={`New thread in ${project.label}`}>
+        <button
+          aria-label={`New thread in ${project.label}`}
+          className='project-action'
+          onClick={() => void onCreateThread(project.path).catch(onError)}
+          type='button'
+        >
+          <PlusIcon />
+        </button>
+      </Tooltip>
+      <Tooltip label={`Archive ${project.label}`}>
+        <button
+          aria-label={`Archive ${project.label}`}
+          className='project-action'
+          onClick={() => onArchiveProject(project.path)}
+          type='button'
+        >
+          <ArchiveIcon />
+        </button>
+      </Tooltip>
+      <div className='project-overflow'>
+        <button
+          aria-expanded={overflowOpen}
+          aria-haspopup='menu'
+          aria-label={`More actions for ${project.label}`}
+          className='project-action'
+          onClick={() => setOverflowOpen((open) => !open)}
+          onBlur={(event) => {
+            if (!event.currentTarget.parentElement?.contains(event.relatedTarget as Node))
+              setOverflowOpen(false)
+          }}
+          type='button'
+        >
+          <OverflowIcon />
+        </button>
+        {overflowOpen && (
+          <div className='project-overflow-menu' role='menu'>
+            <button
+              className='project-overflow-item'
+              onClick={() => {
+                setOverflowOpen(false)
+                onOpenProjectFolder(project.path)
+              }}
+              role='menuitem'
+              type='button'
+            >
+              Open folder
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SessionActions({
+  thread,
+  title,
+  onTogglePin,
+  onArchive,
+}: {
+  thread: ProjectThread
+  title: string
+  onTogglePin: (sessionKey: string) => void
+  onArchive: (sessionKey: string) => void
+}) {
+  return (
+    <div className='project-actions session-actions'>
+      <Tooltip label={thread.pinned ? 'Unpin session' : 'Pin session'}>
+        <button
+          aria-label={thread.pinned ? `Unpin session ${title}` : `Pin session ${title}`}
+          aria-pressed={thread.pinned}
+          className='project-action'
+          onClick={() => onTogglePin(thread.key)}
+          type='button'
+        >
+          <PinIcon />
+        </button>
+      </Tooltip>
+      <Tooltip label='Archive session'>
+        <button
+          aria-label={`Archive session ${title}`}
+          className='project-action'
+          onClick={() => onArchive(thread.key)}
+          type='button'
+        >
+          <ArchiveIcon />
+        </button>
+      </Tooltip>
+    </div>
   )
 }
 
@@ -491,24 +659,6 @@ function WorkspaceIcon() {
       width='16'
     >
       <path d='M3.5 6.5A1.5 1.5 0 0 1 5 5h4l2 2h8A1.5 1.5 0 0 1 20.5 8.5v9A1.5 1.5 0 0 1 19 19H5a1.5 1.5 0 0 1-1.5-1.5v-11Z' />
-    </svg>
-  )
-}
-
-function ChevronIcon() {
-  return (
-    <svg
-      aria-hidden='true'
-      fill='none'
-      height='14'
-      stroke='currentColor'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-      strokeWidth='1.75'
-      viewBox='0 0 24 24'
-      width='14'
-    >
-      <path d='m9 6 6 6-6 6' />
     </svg>
   )
 }
@@ -546,6 +696,24 @@ function PlusIcon() {
       width='16'
     >
       <path d='M12 5v14M5 12h14' />
+    </svg>
+  )
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='none'
+      height='11'
+      stroke='currentColor'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='1.6'
+      viewBox='0 0 12 12'
+      width='11'
+    >
+      <path d='M4 2.5 8 6l-4 3.5' />
     </svg>
   )
 }

--- a/src/features/workspace/WorkspaceSidebar.tsx
+++ b/src/features/workspace/WorkspaceSidebar.tsx
@@ -7,67 +7,71 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react'
 import { Tooltip } from '../../components/Tooltip.tsx'
-import type { RecentSession, SessionSummary } from '../../../shared/types.ts'
-import { sessionIndicator } from './session-indicator.ts'
+import type { SessionSummary } from '../../../shared/types.ts'
+import { defaultWorkerName } from '../../../shared/session-names.ts'
+import { displayThreadTitle } from '../composer/prompt-title.ts'
+import { sessionIndicator, type SessionIndicator } from './session-indicator.ts'
 import { SessionStatusIndicator } from './SessionStatusIndicator.tsx'
-import { otherWorkspaceSessions, sidebarSessions } from './sidebar-sessions.ts'
+import type { ProjectGroup, ProjectThread } from './sidebar-projects.ts'
 import { maxWorkspaceSidebarWidth, minWorkspaceSidebarWidth } from './workspace-sidebar.ts'
 
 interface WorkspaceSidebarProps {
+  collapsed: boolean
   compactingSessionIds: ReadonlySet<string>
   completedSessionIds: ReadonlySet<string>
   isRefreshing: boolean
-  recentSessions: RecentSession[]
-  sentSessions: RecentSession[]
+  projects: ProjectGroup[]
   sessions: SessionSummary[]
   selectedId: string
   width: number
-  workspacePath: string
-  onChooseWorkspace: () => void
-  onCreate: () => Promise<void>
-  onOpenSession: (session: RecentSession) => Promise<void>
-  onSelectOtherWorkspaceSession: (session: SessionSummary) => void
-  onSelectSession: (sessionId: string) => void
+  activeWorkspacePath: string
+  archivedProjects: string[]
+  onToggleCollapsed: () => void
+  onChooseProject: () => void
+  onCreateThread: (projectPath: string) => Promise<void>
+  onActivateThread: (thread: ProjectThread) => Promise<void>
+  onTogglePin: (projectPath: string) => void
+  onArchiveProject: (projectPath: string) => void
+  onUnarchiveProject: (projectPath: string) => void
+  onOpenProjectFolder: (projectPath: string) => void
   onOpenSettings: () => void
   onResize: (width: number) => void
   onError: (cause: unknown) => void
 }
 
-/** Displays the current workspace and opens or selects its recent Pi sessions. */
+/** Displays project-grouped Pi sessions, an explicit project picker, and per-project actions. */
 export function WorkspaceSidebar({
+  collapsed,
   compactingSessionIds,
   completedSessionIds,
   isRefreshing,
-  recentSessions,
-  sentSessions,
+  projects,
   sessions,
   selectedId,
   width,
-  workspacePath,
-  onChooseWorkspace,
-  onCreate,
-  onOpenSession,
-  onSelectOtherWorkspaceSession,
-  onSelectSession,
+  activeWorkspacePath,
+  archivedProjects,
+  onToggleCollapsed,
+  onChooseProject,
+  onCreateThread,
+  onActivateThread,
+  onTogglePin,
+  onArchiveProject,
+  onUnarchiveProject,
+  onOpenProjectFolder,
   onOpenSettings,
   onResize,
   onError,
 }: WorkspaceSidebarProps) {
-  const [openingSessionPath, setOpeningSessionPath] = useState('')
-  const selectedSessionRef = useRef<HTMLButtonElement>(null)
-  const visibleSessions = useMemo(
-    () => sidebarSessions(recentSessions, workspacePath, sentSessions),
-    [recentSessions, sentSessions, workspacePath],
-  )
-  const otherSessions = useMemo(
-    () =>
-      otherWorkspaceSessions(sessions, workspacePath, compactingSessionIds, completedSessionIds),
-    [compactingSessionIds, completedSessionIds, sessions, workspacePath],
+  const selectedThreadRef = useRef<HTMLButtonElement>(null)
+  const totalThreads = useMemo(
+    () => projects.reduce((count, project) => count + project.threads.length, 0),
+    [projects],
   )
 
   useEffect(() => {
-    selectedSessionRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-  }, [selectedId, visibleSessions])
+    selectedThreadRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  }, [selectedId, projects])
 
   function startResize(event: ReactPointerEvent<HTMLDivElement>): void {
     const handle = event.currentTarget
@@ -106,6 +110,44 @@ export function WorkspaceSidebar({
     }
   }
 
+  if (collapsed) {
+    return (
+      <aside className='sidebar sidebar-rail' aria-label='Collapsed session sidebar'>
+        <Tooltip label='Expand sidebar (⌘B)'>
+          <button
+            aria-expanded={false}
+            aria-label='Expand sidebar'
+            className='sidebar-rail-button brand-mark'
+            onClick={onToggleCollapsed}
+            type='button'
+          >
+            π
+          </button>
+        </Tooltip>
+        <Tooltip label='New thread'>
+          <button
+            aria-label='New thread'
+            className='sidebar-rail-button'
+            onClick={() => void onCreateThread(activeWorkspacePath).catch(onError)}
+            type='button'
+          >
+            <PlusIcon />
+          </button>
+        </Tooltip>
+        <Tooltip label='Settings'>
+          <button
+            aria-label='Open settings'
+            className='sidebar-rail-button'
+            onClick={onOpenSettings}
+            type='button'
+          >
+            <SettingsIcon />
+          </button>
+        </Tooltip>
+      </aside>
+    )
+  }
+
   return (
     <aside className='sidebar'>
       <div
@@ -121,10 +163,20 @@ export function WorkspaceSidebar({
         tabIndex={0}
       />
       <div className='brand'>
-        <span className='brand-mark'>π</span>
+        <Tooltip label='Collapse sidebar (⌘B)'>
+          <button
+            aria-expanded
+            aria-label='Collapse sidebar'
+            className='settings-button'
+            onClick={onToggleCollapsed}
+            type='button'
+          >
+            <SidebarToggleIcon />
+          </button>
+        </Tooltip>
         <div>
           <strong>Pi Livecraft</strong>
-          <small>Local workspace</small>
+          <small>Project sessions</small>
         </div>
         <Tooltip label='Settings'>
           <button
@@ -137,118 +189,267 @@ export function WorkspaceSidebar({
           </button>
         </Tooltip>
       </div>
+
       <div className='workspace-group'>
-        <Tooltip label={workspacePath}>
+        <Tooltip label={activeWorkspacePath}>
           <button
-            aria-label={`Choose workspace: ${workspacePath}`}
+            aria-label={`Change project. Current: ${activeWorkspacePath}`}
             className='workspace-path'
-            onClick={onChooseWorkspace}
+            onClick={onChooseProject}
             type='button'
           >
             <WorkspaceIcon />
             <div className='workspace-path-copy'>
-              <span>Current directory</span>
-              <strong>{workspacePath}</strong>
+              <span>Project</span>
+              <strong>{activeWorkspacePath}</strong>
             </div>
             <ChevronIcon />
           </button>
         </Tooltip>
       </div>
-      <NewSessionButton onCreate={onCreate} onError={onError} />
-      <nav className='session-list' aria-label='Recent Pi sessions'>
-        {isRefreshing && visibleSessions.length === 0 && (
+
+      <NewThreadButton
+        onCreate={() => onCreateThread(activeWorkspacePath)}
+        onError={onError}
+      />
+
+      <div className='project-list' aria-label='Projects and their Pi sessions'>
+        {isRefreshing && totalThreads === 0 && (
           <p className='session-list-loading' role='status'>Loading sessions…</p>
         )}
-        {visibleSessions.map((recentSession) => {
-          const activeSession = sessions.find((session) =>
-            session.sessionPath === recentSession.sessionPath && session.status !== 'exited'
-          )
-          const indicator = sessionIndicator(
-            activeSession,
-            selectedId,
-            compactingSessionIds,
-            completedSessionIds,
-          )
-          const sessionLabel = openingSessionPath === recentSession.sessionPath
-            ? 'Opening…'
-            : recentSession.name
-          return (
-            <Tooltip
-              key={recentSession.sessionPath}
-              label={`${recentSession.name}\n${
-                new Date(recentSession.updatedAt).toLocaleString('en-US')
-              }`}
-            >
-              <button
-                className={`session-item${activeSession?.id === selectedId ? ' selected' : ''}${
-                  indicator ? ` ${indicator}` : ''
-                }`}
-                disabled={openingSessionPath === recentSession.sessionPath}
-                onClick={() => {
-                  if (activeSession) {
-                    onSelectSession(activeSession.id)
-                    return
-                  }
-                  setOpeningSessionPath(recentSession.sessionPath)
-                  void onOpenSession(recentSession).catch(onError).finally(() =>
-                    setOpeningSessionPath('')
-                  )
-                }}
-                ref={activeSession?.id === selectedId ? selectedSessionRef : undefined}
-                type='button'
-              >
-                {indicator && <SessionStatusIndicator status={indicator} />}
-                <span>
-                  <strong>{sessionLabel}</strong>
-                </span>
-              </button>
-            </Tooltip>
-          )
-        })}
-        {visibleSessions.length === 0 && !isRefreshing && (
-          <p className='empty-sidebar'>No Pi sessions in this directory.</p>
+        {projects.map((project) => (
+          <ProjectSection
+            key={project.path}
+            project={project}
+            sessions={sessions}
+            selectedId={selectedId}
+            selectedThreadRef={selectedThreadRef}
+            compactingSessionIds={compactingSessionIds}
+            completedSessionIds={completedSessionIds}
+            onCreateThread={onCreateThread}
+            onActivateThread={onActivateThread}
+            onTogglePin={onTogglePin}
+            onArchiveProject={onArchiveProject}
+            onOpenProjectFolder={onOpenProjectFolder}
+            onError={onError}
+          />
+        ))}
+        {!isRefreshing && totalThreads === 0 && (
+          <p className='empty-sidebar'>No Pi sessions yet. Start a new thread above.</p>
         )}
-      </nav>
-      {otherSessions.length > 0 && (
-        <section className='other-workspace-sessions'>
-          <h2>Other workspaces</h2>
-          <nav
-            aria-label='Active and completed sessions in other workspaces'
-            className='other-session-list'
-          >
-            {otherSessions.map((session) => {
-              const indicator = sessionIndicator(
-                session,
-                selectedId,
-                compactingSessionIds,
-                completedSessionIds,
-              )
-              return (
-                <Tooltip key={session.id} label={`${session.name}\n${session.cwd}`}>
-                  <button
-                    aria-label={`${session.name} in workspace ${session.cwd}`}
-                    className={`session-item${indicator ? ` ${indicator}` : ''}`}
-                    onClick={() => onSelectOtherWorkspaceSession(session)}
-                    type='button'
-                  >
-                    {indicator && <SessionStatusIndicator status={indicator} />}
-                    <span>
-                      <strong>{session.name}</strong>
-                      <small>{session.cwd}</small>
-                    </span>
-                  </button>
-                </Tooltip>
-              )
-            })}
-          </nav>
-        </section>
+      </div>
+
+      {archivedProjects.length > 0 && (
+        <details className='archived-projects'>
+          <summary>Archived projects ({archivedProjects.length})</summary>
+          <ul>
+            {archivedProjects.map((path) => (
+              <li key={path}>
+                <span className='archived-project-path' title={path}>{path}</span>
+                <button
+                  aria-label={`Restore archived project ${path}`}
+                  onClick={() => onUnarchiveProject(path)}
+                  type='button'
+                >
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
       )}
     </aside>
   )
 }
 
-/** Prevents duplicate session creation and reports errors to the container. */
-function NewSessionButton(
+interface ProjectSectionProps {
+  project: ProjectGroup
+  sessions: SessionSummary[]
+  selectedId: string
+  selectedThreadRef: React.RefObject<HTMLButtonElement | null>
+  compactingSessionIds: ReadonlySet<string>
+  completedSessionIds: ReadonlySet<string>
+  onCreateThread: (projectPath: string) => Promise<void>
+  onActivateThread: (thread: ProjectThread) => Promise<void>
+  onTogglePin: (projectPath: string) => void
+  onArchiveProject: (projectPath: string) => void
+  onOpenProjectFolder: (projectPath: string) => void
+  onError: (cause: unknown) => void
+}
+
+/** Renders a project divider with scoped actions and the project's ordered threads. */
+function ProjectSection({
+  project,
+  sessions,
+  selectedId,
+  selectedThreadRef,
+  compactingSessionIds,
+  completedSessionIds,
+  onCreateThread,
+  onActivateThread,
+  onTogglePin,
+  onArchiveProject,
+  onOpenProjectFolder,
+  onError,
+}: ProjectSectionProps) {
+  const [overflowOpen, setOverflowOpen] = useState(false)
+  const summary = project.activeCount > 0
+    ? `${project.threads.length} threads · ${project.activeCount} active`
+    : `${project.threads.length} thread${project.threads.length === 1 ? '' : 's'}`
+
+  return (
+    <section className='project-section' aria-label={`Project ${project.label}`}>
+      <div className='project-divider'>
+        <div className='project-divider-copy'>
+          <Tooltip label={project.path}>
+            <h2>
+              {project.pinned && <span aria-hidden='true' className='project-pin-mark'>📌</span>}
+              {project.label}
+            </h2>
+          </Tooltip>
+          <small>{summary}</small>
+        </div>
+        <div className='project-actions'>
+          <Tooltip label={`New thread in ${project.label}`}>
+            <button
+              aria-label={`New thread in ${project.label}`}
+              className='project-action'
+              onClick={() => void onCreateThread(project.path).catch(onError)}
+              type='button'
+            >
+              <PlusIcon />
+            </button>
+          </Tooltip>
+          <Tooltip label={project.pinned ? 'Unpin project' : 'Pin project'}>
+            <button
+              aria-label={project.pinned ? `Unpin ${project.label}` : `Pin ${project.label}`}
+              aria-pressed={project.pinned}
+              className='project-action'
+              onClick={() => onTogglePin(project.path)}
+              type='button'
+            >
+              <PinIcon />
+            </button>
+          </Tooltip>
+          <Tooltip label={`Archive ${project.label}`}>
+            <button
+              aria-label={`Archive ${project.label}`}
+              className='project-action'
+              onClick={() => onArchiveProject(project.path)}
+              type='button'
+            >
+              <ArchiveIcon />
+            </button>
+          </Tooltip>
+          <div className='project-overflow'>
+            <button
+              aria-expanded={overflowOpen}
+              aria-haspopup='menu'
+              aria-label={`More actions for ${project.label}`}
+              className='project-action'
+              onClick={() => setOverflowOpen((open) => !open)}
+              onBlur={(event) => {
+                if (!event.currentTarget.parentElement?.contains(event.relatedTarget as Node))
+                  setOverflowOpen(false)
+              }}
+              type='button'
+            >
+              <OverflowIcon />
+            </button>
+            {overflowOpen && (
+              <div className='project-overflow-menu' role='menu'>
+                <button
+                  className='project-overflow-item'
+                  onClick={() => {
+                    setOverflowOpen(false)
+                    onOpenProjectFolder(project.path)
+                  }}
+                  role='menuitem'
+                  type='button'
+                >
+                  Open folder
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <nav className='session-list project-threads' aria-label={`${project.label} sessions`}>
+        {project.threads.length === 0 && <p className='project-empty'>No threads yet.</p>}
+        {project.threads.map((thread) => {
+          const active = sessions.find((session) =>
+            (thread.sessionPath
+              ? session.sessionPath === thread.sessionPath
+              : session.id === thread.id) && session.status !== 'exited'
+          )
+          const indicator = sessionIndicator(
+            active,
+            selectedId,
+            compactingSessionIds,
+            completedSessionIds,
+          )
+          const isSelected = active?.id === selectedId
+          const worker = active?.activeAgent ?? thread.worker ?? defaultWorkerName
+          const title = displayThreadTitle(thread.name, worker)
+          return (
+            <ThreadItem
+              key={thread.key}
+              indicator={indicator}
+              isSelected={isSelected}
+              selectedThreadRef={isSelected ? selectedThreadRef : undefined}
+              thread={thread}
+              title={title}
+              onActivate={onActivateThread}
+              onError={onError}
+            />
+          )
+        })}
+      </nav>
+    </section>
+  )
+}
+
+interface ThreadItemProps {
+  indicator: SessionIndicator | null
+  isSelected: boolean
+  selectedThreadRef?: React.RefObject<HTMLButtonElement | null>
+  thread: ProjectThread
+  title: string
+  onActivate: (thread: ProjectThread) => Promise<void>
+  onError: (cause: unknown) => void
+}
+
+/** A single selectable thread; shows a transient opening state while a history thread resumes. */
+function ThreadItem(
+  { indicator, isSelected, selectedThreadRef, thread, title, onActivate, onError }: ThreadItemProps,
+) {
+  const [opening, setOpening] = useState(false)
+  return (
+    <Tooltip label={title}>
+      <button
+        className={`session-item${isSelected ? ' selected' : ''}${
+          indicator ? ` ${indicator}` : ''
+        }`}
+        disabled={opening}
+        onClick={() => {
+          setOpening(true)
+          void onActivate(thread).catch(onError).finally(() => setOpening(false))
+        }}
+        ref={selectedThreadRef}
+        type='button'
+      >
+        {indicator && <SessionStatusIndicator status={indicator} />}
+        <span>
+          <strong>{opening ? 'Opening…' : title}</strong>
+        </span>
+      </button>
+    </Tooltip>
+  )
+}
+
+/** Prevents duplicate thread creation and reports errors to the container. */
+function NewThreadButton(
   { onCreate, onError }: { onCreate: () => Promise<void>; onError: (cause: unknown) => void },
 ) {
   const [busy, setBusy] = useState(false)
@@ -271,7 +472,7 @@ function NewSessionButton(
       onClick={() => void create()}
       type='button'
     >
-      {busy ? 'Starting…' : '＋ New session'}
+      {busy ? 'Starting…' : '＋ New thread'}
     </button>
   )
 }
@@ -308,6 +509,96 @@ function ChevronIcon() {
       width='14'
     >
       <path d='m9 6 6 6-6 6' />
+    </svg>
+  )
+}
+
+function SidebarToggleIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='none'
+      height='16'
+      stroke='currentColor'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='1.6'
+      viewBox='0 0 24 24'
+      width='16'
+    >
+      <rect x='3' y='4' width='18' height='16' rx='2' />
+      <path d='M9 4v16' />
+    </svg>
+  )
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='none'
+      height='16'
+      stroke='currentColor'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='1.8'
+      viewBox='0 0 24 24'
+      width='16'
+    >
+      <path d='M12 5v14M5 12h14' />
+    </svg>
+  )
+}
+
+function PinIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='none'
+      height='16'
+      stroke='currentColor'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='1.6'
+      viewBox='0 0 24 24'
+      width='16'
+    >
+      <path d='M9 4h6l-1 6 3 3H7l3-3-1-6ZM12 16v4' />
+    </svg>
+  )
+}
+
+function ArchiveIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='none'
+      height='16'
+      stroke='currentColor'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='1.6'
+      viewBox='0 0 24 24'
+      width='16'
+    >
+      <rect x='3' y='4' width='18' height='4' rx='1' />
+      <path d='M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8M10 12h4' />
+    </svg>
+  )
+}
+
+function OverflowIcon() {
+  return (
+    <svg
+      aria-hidden='true'
+      fill='currentColor'
+      height='16'
+      viewBox='0 0 24 24'
+      width='16'
+    >
+      <circle cx='5' cy='12' r='1.6' />
+      <circle cx='12' cy='12' r='1.6' />
+      <circle cx='19' cy='12' r='1.6' />
     </svg>
   )
 }

--- a/src/features/workspace/project-preferences.ts
+++ b/src/features/workspace/project-preferences.ts
@@ -1,5 +1,8 @@
-export const pinnedProjectsStorageKey = 'pi-livecraft.pinned-projects'
 export const archivedProjectsStorageKey = 'pi-livecraft.archived-projects'
+export const projectOrderStorageKey = 'pi-livecraft.project-order'
+export const pinnedSessionsStorageKey = 'pi-livecraft.pinned-sessions'
+export const archivedSessionsStorageKey = 'pi-livecraft.archived-sessions'
+export const collapsedProjectsStorageKey = 'pi-livecraft.collapsed-projects'
 
 /** Adds or removes a project path from a preference list, returning a new stable-ordered list. */
 export function toggleProjectPath(paths: readonly string[], path: string): string[] {

--- a/src/features/workspace/project-preferences.ts
+++ b/src/features/workspace/project-preferences.ts
@@ -1,0 +1,7 @@
+export const pinnedProjectsStorageKey = 'pi-livecraft.pinned-projects'
+export const archivedProjectsStorageKey = 'pi-livecraft.archived-projects'
+
+/** Adds or removes a project path from a preference list, returning a new stable-ordered list. */
+export function toggleProjectPath(paths: readonly string[], path: string): string[] {
+  return paths.includes(path) ? paths.filter((entry) => entry !== path) : [...paths, path]
+}

--- a/src/features/workspace/sidebar-projects.ts
+++ b/src/features/workspace/sidebar-projects.ts
@@ -1,0 +1,134 @@
+import type { RecentSession, SessionSummary } from '../../../shared/types.ts'
+
+/** A thread shown inside a project section, normalized from recent history or a live managed session. */
+export interface ProjectThread {
+  key: string
+  id: string
+  name: string
+  cwd: string
+  sessionPath?: string
+  updatedAt: number
+  worker?: string
+  live: boolean
+}
+
+/** A project/repository section: a canonical workspace identity, its threads, and an attention summary. */
+export interface ProjectGroup {
+  path: string
+  label: string
+  pinned: boolean
+  isActiveWorkspace: boolean
+  threads: ProjectThread[]
+  activeCount: number
+}
+
+interface GroupProjectsInput {
+  recentSessions: RecentSession[]
+  sessions: SessionSummary[]
+  activeWorkspacePath: string
+  pinnedProjects: readonly string[]
+  archivedProjects: readonly string[]
+}
+
+/** Derives the display label for a project from the trailing segment of its canonical path. */
+export function projectLabel(path: string): string {
+  const segments = path.split(/[/\\]/).filter(Boolean)
+  return segments.at(-1) ?? path
+}
+
+const liveStatuses = new Set(['starting', 'running', 'idle'])
+
+/**
+ * Groups recent and live sessions into project sections keyed by canonical workspace path.
+ *
+ * The active workspace always appears (even when empty) so a thread can be created in it; other
+ * projects appear when they carry live or attention-worthy work, plus any pinned project. Archived
+ * projects are hidden but recoverable through the returned pin/archive preferences. Pinned projects
+ * lead, then the active workspace, then remaining projects by most recent activity — a stable order
+ * that survives refreshes.
+ */
+export function groupProjects(
+  { recentSessions, sessions, activeWorkspacePath, pinnedProjects, archivedProjects }:
+    GroupProjectsInput,
+): ProjectGroup[] {
+  const archived = new Set(archivedProjects)
+  const pinned = new Set(pinnedProjects)
+  const threadsByProject = new Map<string, Map<string, ProjectThread>>()
+
+  const ensure = (cwd: string): Map<string, ProjectThread> => {
+    const existing = threadsByProject.get(cwd)
+    if (existing) return existing
+    const created = new Map<string, ProjectThread>()
+    threadsByProject.set(cwd, created)
+    return created
+  }
+
+  for (const recent of recentSessions) {
+    if (archived.has(recent.cwd)) continue
+    ensure(recent.cwd).set(recent.sessionPath, {
+      key: recent.sessionPath,
+      id: recent.id,
+      name: recent.name,
+      cwd: recent.cwd,
+      sessionPath: recent.sessionPath,
+      updatedAt: recent.updatedAt,
+      live: false,
+    })
+  }
+
+  for (const session of sessions) {
+    if (session.status === 'exited' || archived.has(session.cwd)) continue
+    if (!liveStatuses.has(session.status)) continue
+    const key = session.sessionPath ?? session.id
+    const project = ensure(session.cwd)
+    const previous = project.get(key)
+    project.set(key, {
+      key,
+      id: session.id,
+      name: session.name,
+      cwd: session.cwd,
+      sessionPath: session.sessionPath,
+      updatedAt: previous?.updatedAt ?? Date.now(),
+      worker: session.activeAgent,
+      live: true,
+    })
+  }
+
+  if (!threadsByProject.has(activeWorkspacePath) && !archived.has(activeWorkspacePath))
+    ensure(activeWorkspacePath)
+  for (const path of pinned) {
+    if (!threadsByProject.has(path) && !archived.has(path)) ensure(path)
+  }
+
+  const groups = [...threadsByProject.entries()].map(([path, threads]): ProjectGroup => {
+    const ordered = [...threads.values()].sort(compareThreads)
+    return {
+      path,
+      label: projectLabel(path),
+      pinned: pinned.has(path),
+      isActiveWorkspace: path === activeWorkspacePath,
+      threads: ordered,
+      activeCount: ordered.filter((thread) => thread.live).length,
+    }
+  })
+
+  return groups.sort(compareGroups)
+}
+
+function compareThreads(left: ProjectThread, right: ProjectThread): number {
+  if (left.live !== right.live) return left.live ? -1 : 1
+  return right.updatedAt - left.updatedAt
+}
+
+function compareGroups(left: ProjectGroup, right: ProjectGroup): number {
+  if (left.pinned !== right.pinned) return left.pinned ? -1 : 1
+  if (left.isActiveWorkspace !== right.isActiveWorkspace) return left.isActiveWorkspace ? -1 : 1
+  const leftLatest = latestActivity(left)
+  const rightLatest = latestActivity(right)
+  if (leftLatest !== rightLatest) return rightLatest - leftLatest
+  return left.label.localeCompare(right.label)
+}
+
+function latestActivity(group: ProjectGroup): number {
+  return group.threads.reduce((latest, thread) => Math.max(latest, thread.updatedAt), 0)
+}

--- a/src/features/workspace/sidebar-projects.ts
+++ b/src/features/workspace/sidebar-projects.ts
@@ -1,4 +1,4 @@
-import type { RecentSession, SessionSummary } from '../../../shared/types.ts'
+import type { RecentSession, SessionModel, SessionSummary } from '../../../shared/types.ts'
 
 /** A thread shown inside a project section, normalized from recent history or a live managed session. */
 export interface ProjectThread {
@@ -9,6 +9,9 @@ export interface ProjectThread {
   sessionPath?: string
   updatedAt: number
   worker?: string
+  model?: SessionModel
+  thinkingLevel?: string
+  pinned: boolean
   live: boolean
 }
 
@@ -16,9 +19,9 @@ export interface ProjectThread {
 export interface ProjectGroup {
   path: string
   label: string
-  pinned: boolean
   isActiveWorkspace: boolean
   threads: ProjectThread[]
+  archivedThreads: ProjectThread[]
   activeCount: number
 }
 
@@ -26,8 +29,10 @@ interface GroupProjectsInput {
   recentSessions: RecentSession[]
   sessions: SessionSummary[]
   activeWorkspacePath: string
-  pinnedProjects: readonly string[]
+  projectOrder?: readonly string[]
   archivedProjects: readonly string[]
+  pinnedSessions?: readonly string[]
+  archivedSessions?: readonly string[]
 }
 
 /** Derives the display label for a project from the trailing segment of its canonical path. */
@@ -42,18 +47,26 @@ const liveStatuses = new Set(['starting', 'running', 'idle'])
  * Groups recent and live sessions into project sections keyed by canonical workspace path.
  *
  * The active workspace always appears (even when empty) so a thread can be created in it; other
- * projects appear when they carry live or attention-worthy work, plus any pinned project. Archived
- * projects are hidden but recoverable through the returned pin/archive preferences. Pinned projects
- * lead, then the active workspace, then remaining projects by most recent activity — a stable order
- * that survives refreshes.
+ * projects appear when they carry live or attention-worthy work. Archived projects are hidden but
+ * recoverable. A manually dragged `projectOrder` wins; unordered projects follow with the active
+ * workspace first, then most recent activity — a stable order that survives refreshes.
  */
 export function groupProjects(
-  { recentSessions, sessions, activeWorkspacePath, pinnedProjects, archivedProjects }:
-    GroupProjectsInput,
+  {
+    recentSessions,
+    sessions,
+    activeWorkspacePath,
+    projectOrder = [],
+    archivedProjects,
+    pinnedSessions = [],
+    archivedSessions = [],
+  }: GroupProjectsInput,
 ): ProjectGroup[] {
   const archived = new Set(archivedProjects)
-  const pinned = new Set(pinnedProjects)
+  const pinnedThreadKeys = new Set(pinnedSessions)
+  const archivedThreadKeys = new Set(archivedSessions)
   const threadsByProject = new Map<string, Map<string, ProjectThread>>()
+  const archivedThreadsByProject = new Map<string, Map<string, ProjectThread>>()
 
   const ensure = (cwd: string): Map<string, ProjectThread> => {
     const existing = threadsByProject.get(cwd)
@@ -63,26 +76,42 @@ export function groupProjects(
     return created
   }
 
+  const ensureArchived = (cwd: string): Map<string, ProjectThread> => {
+    const existing = archivedThreadsByProject.get(cwd)
+    if (existing) return existing
+    const created = new Map<string, ProjectThread>()
+    archivedThreadsByProject.set(cwd, created)
+    return created
+  }
+
   for (const recent of recentSessions) {
     if (archived.has(recent.cwd)) continue
-    ensure(recent.cwd).set(recent.sessionPath, {
+    const thread: ProjectThread = {
       key: recent.sessionPath,
       id: recent.id,
       name: recent.name,
       cwd: recent.cwd,
       sessionPath: recent.sessionPath,
       updatedAt: recent.updatedAt,
+      model: recent.model,
+      thinkingLevel: recent.thinkingLevel,
+      pinned: pinnedThreadKeys.has(recent.sessionPath),
       live: false,
-    })
+    }
+    if (archivedThreadKeys.has(recent.sessionPath))
+      ensureArchived(recent.cwd).set(thread.key, thread)
+    else ensure(recent.cwd).set(thread.key, thread)
   }
 
   for (const session of sessions) {
     if (session.status === 'exited' || archived.has(session.cwd)) continue
     if (!liveStatuses.has(session.status)) continue
     const key = session.sessionPath ?? session.id
+    const archivedKey = archivedThreadKeys.has(key) || archivedThreadKeys.has(session.id)
     const project = ensure(session.cwd)
-    const previous = project.get(key)
-    project.set(key, {
+    const target = archivedKey ? ensureArchived(session.cwd) : project
+    const previous = target.get(key)
+    target.set(key, {
       key,
       id: session.id,
       name: session.name,
@@ -90,38 +119,47 @@ export function groupProjects(
       sessionPath: session.sessionPath,
       updatedAt: previous?.updatedAt ?? Date.now(),
       worker: session.activeAgent,
+      model: session.model ?? previous?.model,
+      thinkingLevel: session.thinkingLevel ?? previous?.thinkingLevel,
+      pinned: pinnedThreadKeys.has(key) || pinnedThreadKeys.has(session.id),
       live: true,
     })
   }
 
   if (!threadsByProject.has(activeWorkspacePath) && !archived.has(activeWorkspacePath))
     ensure(activeWorkspacePath)
-  for (const path of pinned) {
-    if (!threadsByProject.has(path) && !archived.has(path)) ensure(path)
-  }
 
-  const groups = [...threadsByProject.entries()].map(([path, threads]): ProjectGroup => {
+  const paths = new Set([...threadsByProject.keys(), ...archivedThreadsByProject.keys()])
+  const groups = [...paths].map((path): ProjectGroup => {
+    const threads = threadsByProject.get(path) ?? new Map<string, ProjectThread>()
+    const archivedThreads = archivedThreadsByProject.get(path) ?? new Map<string, ProjectThread>()
     const ordered = [...threads.values()].sort(compareThreads)
     return {
       path,
       label: projectLabel(path),
-      pinned: pinned.has(path),
       isActiveWorkspace: path === activeWorkspacePath,
       threads: ordered,
+      archivedThreads: [...archivedThreads.values()].sort(compareThreads),
       activeCount: ordered.filter((thread) => thread.live).length,
     }
   })
 
-  return groups.sort(compareGroups)
+  const orderIndex = new Map(projectOrder.map((path, index) => [path, index]))
+  return groups.sort((left, right) => {
+    const leftIndex = orderIndex.get(left.path) ?? Number.MAX_SAFE_INTEGER
+    const rightIndex = orderIndex.get(right.path) ?? Number.MAX_SAFE_INTEGER
+    if (leftIndex !== rightIndex) return leftIndex - rightIndex
+    return compareGroups(left, right)
+  })
 }
 
 function compareThreads(left: ProjectThread, right: ProjectThread): number {
+  if (left.pinned !== right.pinned) return left.pinned ? -1 : 1
   if (left.live !== right.live) return left.live ? -1 : 1
   return right.updatedAt - left.updatedAt
 }
 
 function compareGroups(left: ProjectGroup, right: ProjectGroup): number {
-  if (left.pinned !== right.pinned) return left.pinned ? -1 : 1
   if (left.isActiveWorkspace !== right.isActiveWorkspace) return left.isActiveWorkspace ? -1 : 1
   const leftLatest = latestActivity(left)
   const rightLatest = latestActivity(right)

--- a/src/features/workspace/useWorkspaceSessions.ts
+++ b/src/features/workspace/useWorkspaceSessions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { listDirectories, listRecentSessions, listSessions, sendPiCommand } from '../../api.ts'
 import type { JsonObject, RecentSession, SessionSummary } from '../../../shared/types.ts'
 import { promptSessionTitle } from '../composer/prompt-title.ts'
+import { unnamedSessionName } from '../../../shared/session-names.ts'
 import { recentWorkspaces } from './recent-workspaces.ts'
 import { pickSessionOnOpen, sidebarSessions } from './sidebar-sessions.ts'
 
@@ -115,7 +116,7 @@ export function useWorkspaceSessions(
         const previousName = sessionsRef.current.find((current) => current.id === session.id)?.name
         return recentName
           ? { ...session, name: recentName }
-          : previousName && previousName !== 'Nouvelle session'
+          : previousName && previousName !== unnamedSessionName
           ? { ...session, name: previousName }
           : session
       })

--- a/src/features/workspace/workspace-sidebar.ts
+++ b/src/features/workspace/workspace-sidebar.ts
@@ -10,3 +10,9 @@ export function clampWorkspaceSidebarWidth(width: number): number {
 export function readWorkspaceSidebarWidth(value: string | null): number {
   return value === null ? defaultWorkspaceSidebarWidth : clampWorkspaceSidebarWidth(Number(value))
 }
+
+export const workspaceSidebarCollapsedKey = 'pi-livecraft.sidebar-collapsed'
+
+export function readWorkspaceSidebarCollapsed(value: string | null): boolean {
+  return value === 'true'
+}

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -126,150 +126,10 @@
   font-size: 38px;
 }
 
-.workspace-group {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.sidebar-actions {
-  display: flex;
-  gap: 4px;
-  padding: 2px 0 0;
-}
-.sidebar-action {
+.sidebar-rail-actions {
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 10px;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--ink);
-  font-size: 11.5px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 180ms ease, border-color 180ms ease;
-}
-.sidebar-action:hover, .sidebar-action:focus-visible {
-  border-color: var(--line-strong);
-  background: color-mix(in srgb, var(--ink) 6%, transparent);
-}
-.sidebar-action:disabled {
-  opacity: 0.45;
-  cursor: default;
-}
-.sidebar-action svg {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: currentColor;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 2;
-}
-
-.workspace-path {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  min-width: 0;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
-  border-radius: 10px;
-  padding: 8px 9px;
-  background: transparent;
-  color: var(--ink);
-  text-align: left;
-  transition: background 180ms ease, border-color 180ms ease;
-}
-.workspace-path:hover {
-  border-color: color-mix(in srgb, var(--accent) 32%, var(--line-strong));
-  background: var(--accent-soft);
-}
-.workspace-path:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
-}
-.workspace-path > svg:first-child {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 auto;
-  color: var(--accent);
-}
-.workspace-path-copy {
-  display: grid;
-  flex: 1;
   gap: 2px;
-  min-width: 0;
-}
-.workspace-path-copy > span {
-  overflow: hidden;
-  color: var(--muted);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-overflow: ellipsis;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-.workspace-path-copy > strong {
-  display: block;
-  min-width: 0;
-  overflow: hidden;
-  color: var(--ink);
-  font: 12px/1.35 ui-monospace, monospace;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.workspace-path > svg:last-child {
-  width: 14px;
-  height: 14px;
-  flex: 0 0 auto;
-  color: var(--muted);
-  transition: color 180ms ease, transform 180ms ease;
-}
-.workspace-path:hover > svg:last-child,
-.workspace-path:focus-visible > svg:last-child {
-  color: var(--accent-hover);
-  transform: translateX(1px);
-}
-
-.new-session {
-  width: 100%;
-  height: 44px;
-  margin-bottom: 4px;
-  border: 1px solid var(--accent);
-  border-radius: 9px;
-  padding: 0 12px;
-  background: var(--accent);
-  color: var(--on-accent);
-  font-size: 13px;
-  font-weight: 700;
-  box-shadow:
-    0 2px 0 var(--accent-hover),
-    0 5px 10px color-mix(in srgb, var(--accent) 16%, transparent);
-  transition:
-    background 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
-}
-.new-session:hover:not(:disabled) {
-  background: var(--accent-hover);
-  box-shadow:
-    0 1px 0 color-mix(in srgb, var(--accent-hover) 50%, black),
-    0 4px 8px color-mix(in srgb, var(--accent) 18%, transparent);
-  transform: translateY(1px);
-}
-.new-session:active:not(:disabled) {
-  transform: scale(0.97);
-}
-.new-session:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-  box-shadow: none;
-  transform: none;
 }
 
 .session-list {
@@ -303,6 +163,35 @@
     border-color 180ms ease,
     box-shadow 180ms ease,
     transform 180ms ease;
+}
+.session-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  position: relative;
+}
+/* Hover actions float over the row's right edge so the title keeps the full width. */
+.session-row > .session-actions {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  padding: 2px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.08);
+  pointer-events: none;
+}
+.session-row:hover > .session-actions,
+.session-row:focus-within > .session-actions {
+  pointer-events: auto;
+}
+/* The tooltip wrapper is display:contents, so the button itself is the row's flex item. */
+.session-row .session-item {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
 }
 .session-item:hover:not(:disabled) {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
@@ -341,6 +230,31 @@
   font-size: 13px;
   font-weight: 400;
   letter-spacing: -0.01em;
+}
+.session-item .session-meta {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 1px;
+}
+.session-pin-mark {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+.session-pin-mark svg {
+  width: 11px;
+  height: 11px;
+}
+.project-section.drag-over {
+  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
+.project-divider[draggable="true"] {
+  cursor: grab;
+}
+.project-divider[draggable="true"]:active {
+  cursor: grabbing;
 }
 .session-item.selected strong {
   color: var(--accent-hover);
@@ -500,6 +414,29 @@
   display: flex;
   flex-direction: column;
 }
+.directory-picker-intro {
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.directory-picker-open {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 38px;
+  margin-top: 12px;
+}
+.directory-picker-open svg {
+  width: 16px;
+  height: 16px;
+}
+.directory-picker-empty {
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
 .recent-workspaces {
   margin-top: 12px;
 }
@@ -532,54 +469,6 @@
   background: var(--accent-soft);
   color: var(--accent-hover);
 }
-.directory-path-label {
-  margin: 12px 0 5px;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-.directory-path-input {
-  width: 100%;
-  border: 1px solid var(--line-strong);
-  border-radius: 9px;
-  padding: 10px 11px;
-  background: var(--surface-raised);
-  color: var(--ink);
-  font: 13px ui-monospace, monospace;
-}
-.directory-path-input:focus {
-  outline: 0;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
-}
-.modal .directory-path-hint {
-  margin: 6px 0 0;
-  color: var(--muted);
-  font-size: 11px;
-}
-.directory-suggestions {
-  max-height: 180px;
-  margin-top: 8px;
-  overflow: auto;
-  border: 1px solid var(--line);
-  border-radius: 9px;
-  background: var(--surface-raised);
-}
-.directory-suggestions [role="option"] {
-  overflow: hidden;
-  padding: 8px 10px;
-  color: var(--ink);
-  cursor: pointer;
-  font: 12px ui-monospace, monospace;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.directory-suggestions [role="option"]:hover,
-.directory-suggestions [role="option"].active {
-  background: var(--accent-soft);
-  color: var(--accent-hover);
-}
-
 /* ── Collapsed sidebar rail ─────────────────────────────────────────── */
 .sidebar-rail {
   align-items: center;
@@ -644,6 +533,32 @@
   flex: 1;
   min-width: 0;
 }
+button.project-collapse-toggle {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+button.project-collapse-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 4px;
+}
+.project-collapse-chevron {
+  display: inline-flex;
+  color: var(--muted);
+  transition: transform 150ms ease;
+}
+button.project-collapse-toggle[aria-expanded="true"] .project-collapse-chevron {
+  transform: rotate(90deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .project-collapse-chevron {
+    transition: none;
+  }
+}
 .project-divider-copy h2 {
   display: flex;
   align-items: center;
@@ -674,8 +589,10 @@
   opacity: 0;
   transition: opacity 150ms ease;
 }
-.project-section:hover .project-actions,
-.project-section:focus-within .project-actions {
+.project-divider:hover > .project-actions,
+.project-divider:focus-within > .project-actions,
+.session-row:hover > .project-actions,
+.session-row:focus-within > .project-actions {
   opacity: 1;
 }
 .project-action {

--- a/src/features/workspace/workspace.css
+++ b/src/features/workspace/workspace.css
@@ -579,3 +579,265 @@
   background: var(--accent-soft);
   color: var(--accent-hover);
 }
+
+/* ── Collapsed sidebar rail ─────────────────────────────────────────── */
+.sidebar-rail {
+  align-items: center;
+  gap: 10px;
+  padding: 14px 6px;
+}
+.sidebar-rail-button {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 180ms ease, border-color 180ms ease, color 180ms ease;
+}
+.sidebar-rail-button:hover, .sidebar-rail-button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--line-strong));
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  outline: 0;
+}
+.sidebar-rail-button.brand-mark {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--on-accent);
+  font: 500 20px ui-monospace, monospace;
+}
+
+/* ── Project list and sections ──────────────────────────────────────── */
+.project-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  overflow-y: auto;
+  margin-right: -12px;
+  padding-right: 8px;
+  scrollbar-width: thin;
+}
+.project-list::-webkit-scrollbar {
+  width: 6px;
+}
+.project-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.project-divider {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 2px 6px 4px;
+  border-bottom: 1px solid var(--line);
+}
+.project-divider-copy {
+  flex: 1;
+  min-width: 0;
+}
+.project-divider-copy h2 {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.project-pin-mark {
+  font-size: 10px;
+}
+.project-divider-copy small {
+  display: block;
+  margin-top: 1px;
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+}
+.project-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+.project-section:hover .project-actions,
+.project-section:focus-within .project-actions {
+  opacity: 1;
+}
+.project-action {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+.project-action:hover, .project-action:focus-visible {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  color: var(--ink);
+  outline: 0;
+}
+.project-action[aria-pressed="true"] {
+  color: var(--accent);
+}
+.project-action svg {
+  width: 15px;
+  height: 15px;
+}
+.project-overflow {
+  position: relative;
+}
+.project-overflow-menu {
+  position: absolute;
+  z-index: 3;
+  top: calc(100% + 3px);
+  right: 0;
+  min-width: 140px;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  padding: 4px;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow);
+}
+.project-overflow-item {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-radius: 6px;
+  padding: 7px 9px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 12px;
+  text-align: left;
+}
+.project-overflow-item:hover, .project-overflow-item:focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  outline: 0;
+}
+.project-threads {
+  flex: 0 0 auto;
+  overflow: visible;
+  margin-right: 0;
+  padding-right: 0;
+}
+.project-empty {
+  padding: 6px 10px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+/* ── Archived projects recovery ─────────────────────────────────────── */
+.archived-projects {
+  flex: 0 0 auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--line);
+}
+.archived-projects > summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.archived-projects ul {
+  display: grid;
+  gap: 4px;
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.archived-projects li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.archived-project-path {
+  flex: 1;
+  overflow: hidden;
+  color: var(--ink);
+  font: 11px ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.archived-projects li button {
+  flex: 0 0 auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  padding: 4px 8px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 11px;
+}
+.archived-projects li button:hover, .archived-projects li button:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  outline: 0;
+}
+
+/* ── Project picker additions ───────────────────────────────────────── */
+.project-picker-current {
+  display: grid;
+  gap: 2px;
+  margin-top: 6px;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line));
+  border-radius: 9px;
+  background: var(--accent-soft);
+}
+.project-picker-current > span {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.project-picker-current > strong {
+  color: var(--ink);
+  font-size: 13px;
+}
+.project-picker-current > small {
+  overflow: hidden;
+  color: var(--muted);
+  font: 11px ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.project-picker-option {
+  display: grid !important;
+  gap: 1px;
+}
+.project-picker-option-label {
+  font: 12px/1.3 var(--font, inherit);
+  font-weight: 600;
+}
+.project-picker-option-path {
+  overflow: hidden;
+  color: var(--muted);
+  font: 10px ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -129,27 +129,12 @@ button:disabled, select:disabled {
   --shadow-soft: 0 3px 10px rgb(0 0 0 / 18%);
 
   /* ── sidebar / workspace ── */
-  .sidebar-action:hover,
-  .sidebar-action:focus-visible {
-    background: color-mix(in srgb, var(--ink) 6%, transparent);
-  }
   .session-item:hover {
     background: color-mix(in srgb, var(--accent) 10%, transparent);
   }
   .session-item.selected {
     border-color: color-mix(in srgb, var(--accent) 45%, transparent);
   }
-  .new-session:not(:disabled) {
-    box-shadow:
-      0 2px 0 color-mix(in srgb, var(--accent-hover) 35%, black),
-      0 5px 10px rgb(0 0 0 / 18%);
-  }
-  .new-session:hover:not(:disabled) {
-    box-shadow:
-      0 1px 0 color-mix(in srgb, var(--accent-hover) 25%, black),
-      0 4px 8px rgb(0 0 0 / 20%);
-  }
-
   /* ── composer ── */
   .composer:focus-within {
     border-color: transparent;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -102,6 +102,16 @@ button:disabled, select:disabled {
   grid-template-columns:
     var(--workspace-sidebar-width, 272px) minmax(0, 1fr) 48px;
 }
+.app-shell.sidebar-collapsed {
+  grid-template-columns: 52px minmax(0, 1fr);
+}
+.app-shell.sidebar-collapsed.right-sidebar-visible {
+  grid-template-columns:
+    52px minmax(0, 1fr) calc(var(--right-sidebar-width, 300px) + 48px);
+}
+.app-shell.sidebar-collapsed.right-sidebar-collapsed {
+  grid-template-columns: 52px minmax(0, 1fr) 48px;
+}
 
 .workspace {
   position: relative;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -97,7 +97,7 @@
   }
   .sidebar {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     gap: 12px;
     padding: 12px 14px;
     border-right: 0;
@@ -109,51 +109,32 @@
     min-width: 0;
     margin-bottom: 0;
   }
-  .workspace-group {
+  /* Sessions keep the vertical desktop layout on mobile: full-width rows in a capped scroll area. */
+  .project-list {
     grid-row: 2;
     grid-column: 1 / -1;
-  }
-  .workspace-path {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .workspace-path span {
-    flex: 0 0 auto;
-  }
-  .workspace-path strong {
-    display: block;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .new-session {
-    grid-row: 1;
-    grid-column: 2;
-    align-self: center;
-    width: auto;
-    margin-bottom: 0;
-    padding-inline: 13px;
+    max-height: 38dvh;
+    overflow-y: auto;
   }
   .session-list {
     grid-row: 3;
     grid-column: 1 / -1;
-    display: flex;
-    flex-direction: row;
-    overflow-x: auto;
+    overflow-y: visible;
   }
   .other-workspace-sessions {
     grid-column: 1 / -1;
-    max-height: none;
+    max-height: 30dvh;
   }
-  .other-session-list {
-    flex-direction: row;
-    overflow-x: auto;
-    overflow-y: hidden;
-  }
-  .session-item {
-    min-width: 220px;
+  /* Touch has no hover: session actions stay fixed in the row, always visible. */
+  .session-row > .session-actions {
+    position: static;
+    transform: none;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    opacity: 1;
+    pointer-events: auto;
   }
   .workspace {
     flex: 1;
@@ -179,9 +160,6 @@
   }
   .brand small {
     display: none;
-  }
-  .new-session {
-    font-size: 12px;
   }
   .conversation {
     padding: 20px 12px;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -69,6 +69,15 @@
   .app-shell.right-sidebar-collapsed {
     grid-template-columns: clamp(220px, 22.67vw, 272px) minmax(0, 1fr) 48px;
   }
+  .app-shell.sidebar-collapsed {
+    grid-template-columns: 52px minmax(0, 1fr);
+  }
+  .app-shell.sidebar-collapsed.right-sidebar-visible {
+    grid-template-columns: 52px minmax(0, 1fr) clamp(288px, 29vw, 348px);
+  }
+  .app-shell.sidebar-collapsed.right-sidebar-collapsed {
+    grid-template-columns: 52px minmax(0, 1fr) 48px;
+  }
   .sidebar-resize-handle,
   .right-sidebar-resize-handle {
     display: none;

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { discoverCapabilities, resolvePiAgentDirectory } from '../server/capabilities.ts'
+
+async function fixture(): Promise<{ agentDir: string; cwd: string }> {
+  return {
+    agentDir: await mkdtemp(join(tmpdir(), 'pi-agent-')),
+    cwd: await mkdtemp(join(tmpdir(), 'pi-workspace-')),
+  }
+}
+
+test('resolves Pi agent directory with Pi environment precedence', () => {
+  const homeDirectory = join('home', 'user')
+  const agentDirectory = join('infrastructure', '.pi', 'agent')
+
+  assert.equal(
+    resolvePiAgentDirectory({ PI_CODING_AGENT_DIR: agentDirectory }, homeDirectory),
+    agentDirectory,
+  )
+  assert.equal(
+    resolvePiAgentDirectory({}, homeDirectory),
+    join(homeDirectory, '.pi', 'agent'),
+  )
+})
+
+test('discovers a skill from SKILL.md frontmatter', async () => {
+  const { agentDir, cwd } = await fixture()
+  const skillDirectory = join(agentDir, 'skills', 'creator')
+  await mkdir(skillDirectory, { recursive: true })
+  await writeFile(
+    join(skillDirectory, 'SKILL.md'),
+    '---\nname: creatorskill\ndescription: Creates things.\n---\n\nBody text.\n',
+  )
+
+  const inventory = await discoverCapabilities(cwd, agentDir)
+  assert.equal(inventory.skills.length, 1)
+  assert.deepEqual(
+    { name: inventory.skills[0].name, description: inventory.skills[0].description },
+    { name: 'creatorskill', description: 'Creates things.' },
+  )
+  assert.equal(inventory.skills[0].scope, 'user')
+  assert.equal(inventory.skills[0].origin, 'Pi agent')
+  assert.equal(inventory.skills[0].enabled, true)
+  assert.equal(inventory.skillsError, undefined)
+})
+
+test('discovers an extension subdirectory', async () => {
+  const { agentDir, cwd } = await fixture()
+  const extensionDirectory = join(cwd, '.pi', 'extensions', 'browser-tools')
+  await mkdir(extensionDirectory, { recursive: true })
+  await writeFile(
+    join(extensionDirectory, 'package.json'),
+    JSON.stringify({ description: 'Browser automation tools.' }),
+  )
+
+  const inventory = await discoverCapabilities(cwd, agentDir)
+  assert.equal(inventory.extensions.length, 1)
+  assert.deepEqual(
+    {
+      name: inventory.extensions[0].name,
+      description: inventory.extensions[0].description,
+      scope: inventory.extensions[0].scope,
+      origin: inventory.extensions[0].origin,
+    },
+    {
+      name: 'browser-tools',
+      description: 'Browser automation tools.',
+      scope: 'project',
+      origin: 'Project (.pi)',
+    },
+  )
+  assert.equal(inventory.extensionsError, undefined)
+})
+
+test('treats a missing root as an empty list without an error', async () => {
+  const { agentDir, cwd } = await fixture()
+
+  const inventory = await discoverCapabilities(cwd, agentDir)
+  assert.deepEqual(inventory.skills, [])
+  assert.deepEqual(inventory.extensions, [])
+  assert.equal(inventory.skillsError, undefined)
+  assert.equal(inventory.extensionsError, undefined)
+})
+
+test('fails closed when a skills root is a file instead of a directory', async () => {
+  const { agentDir, cwd } = await fixture()
+  await mkdir(agentDir, { recursive: true })
+  await writeFile(join(agentDir, 'skills'), 'not a directory')
+
+  const inventory = await discoverCapabilities(cwd, agentDir)
+  assert.deepEqual(inventory.skills, [])
+  assert.equal(typeof inventory.skillsError, 'string')
+  assert.ok(inventory.skillsError && inventory.skillsError.length > 0)
+})

--- a/test/project-preferences.test.ts
+++ b/test/project-preferences.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { toggleProjectPath } from '../src/features/workspace/project-preferences.ts'
+
+test('toggleProjectPath adds a missing path, preserving existing order', () => {
+  assert.deepEqual(toggleProjectPath(['/a'], '/b'), ['/a', '/b'])
+})
+
+test('toggleProjectPath removes a present path', () => {
+  assert.deepEqual(toggleProjectPath(['/a', '/b'], '/a'), ['/b'])
+})
+
+test('toggleProjectPath round-trips to the original list', () => {
+  const once = toggleProjectPath(['/a'], '/b')
+  assert.deepEqual(toggleProjectPath(once, '/b'), ['/a'])
+})

--- a/test/prompt-title.test.ts
+++ b/test/prompt-title.test.ts
@@ -1,8 +1,33 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { promptSessionTitle } from '../src/features/composer/prompt-title.ts'
+import {
+  composeThreadTitle,
+  displayThreadTitle,
+  promptSessionTitle,
+} from '../src/features/composer/prompt-title.ts'
 
 test('normalizes and truncates the prompt used as the immediate session title', () => {
   assert.equal(promptSessionTitle('  First\n\tprompt  '), 'First prompt')
   assert.equal(promptSessionTitle('a'.repeat(100)), `${'a'.repeat(89)}…`)
+})
+
+test('composeThreadTitle joins worker and context, and falls back to a default worker', () => {
+  assert.equal(composeThreadTitle('glmpi', 'Livecraft bootstrap'), 'glmpi — Livecraft bootstrap')
+  assert.equal(composeThreadTitle('', 'Only context'), 'Pi — Only context')
+  assert.equal(composeThreadTitle('glmpi', ''), 'glmpi')
+})
+
+test('displayThreadTitle never renders a blank or generic thread title', () => {
+  assert.equal(displayThreadTitle('', 'glmpi'), 'glmpi')
+  assert.equal(displayThreadTitle('Nouvelle session', 'glmpi'), 'glmpi')
+  assert.equal(displayThreadTitle('New session', undefined), 'Pi')
+  assert.equal(displayThreadTitle(undefined, undefined), 'Pi')
+})
+
+test('displayThreadTitle prefixes the worker and preserves it across a later Pi rename', () => {
+  assert.equal(displayThreadTitle('First prompt', 'glmpi'), 'glmpi — First prompt')
+  // A Pi-generated rename arrives as plain context; the current worker is re-applied.
+  assert.equal(displayThreadTitle('Generated title', 'glmpi'), 'glmpi — Generated title')
+  // Re-composition is idempotent when the stored value already carries the same worker prefix.
+  assert.equal(displayThreadTitle('Pi — First prompt', 'Pi'), 'Pi — First prompt')
 })

--- a/test/sidebar-projects.test.ts
+++ b/test/sidebar-projects.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { RecentSession, SessionSummary } from '../shared/types.ts'
+import { groupProjects, projectLabel } from '../src/features/workspace/sidebar-projects.ts'
+
+const recent = (over: Partial<RecentSession>): RecentSession => ({
+  id: 'r',
+  cwd: '/Users/dev/alpha',
+  name: 'A thread',
+  sessionPath: '/sessions/a.jsonl',
+  updatedAt: 100,
+  ...over,
+})
+
+const live = (over: Partial<SessionSummary>): SessionSummary => ({
+  id: 's',
+  cwd: '/Users/dev/beta',
+  name: 'Live thread',
+  sessionPath: '/sessions/live.jsonl',
+  status: 'running',
+  pendingUi: [],
+  ...over,
+})
+
+const base = {
+  pinnedProjects: [] as string[],
+  archivedProjects: [] as string[],
+}
+
+test('projectLabel uses the trailing path segment', () => {
+  assert.equal(projectLabel('/Users/dev/llm-collab'), 'llm-collab')
+  assert.equal(projectLabel('/Users/dev/nuvyr_app/'), 'nuvyr_app')
+})
+
+test('separates two projects into independent sections', () => {
+  const groups = groupProjects({
+    recentSessions: [recent({})],
+    sessions: [live({})],
+    activeWorkspacePath: '/Users/dev/alpha',
+    ...base,
+  })
+  assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/alpha', '/Users/dev/beta'])
+  assert.equal(groups[0].threads.length, 1)
+  assert.equal(groups[1].threads.length, 1)
+  assert.equal(groups[1].activeCount, 1)
+})
+
+test('always shows the active workspace even when it has no threads', () => {
+  const groups = groupProjects({
+    recentSessions: [],
+    sessions: [],
+    activeWorkspacePath: '/Users/dev/empty',
+    ...base,
+  })
+  assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/empty'])
+  assert.equal(groups[0].threads.length, 0)
+})
+
+test('pinned projects lead and are marked, surviving refresh order', () => {
+  const groups = groupProjects({
+    recentSessions: [recent({ updatedAt: 10 })],
+    sessions: [live({ cwd: '/Users/dev/beta' })],
+    activeWorkspacePath: '/Users/dev/alpha',
+    pinnedProjects: ['/Users/dev/beta'],
+    archivedProjects: [],
+  })
+  assert.equal(groups[0].path, '/Users/dev/beta')
+  assert.equal(groups[0].pinned, true)
+})
+
+test('archived projects are hidden from the grouping', () => {
+  const groups = groupProjects({
+    recentSessions: [recent({})],
+    sessions: [live({})],
+    activeWorkspacePath: '/Users/dev/alpha',
+    pinnedProjects: [],
+    archivedProjects: ['/Users/dev/beta'],
+  })
+  assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/alpha'])
+})
+
+test('orders threads with live sessions first, then by recency', () => {
+  const groups = groupProjects({
+    recentSessions: [
+      recent({ sessionPath: '/sessions/old.jsonl', updatedAt: 50 }),
+      recent({ sessionPath: '/sessions/newer.jsonl', updatedAt: 300 }),
+    ],
+    sessions: [live({ cwd: '/Users/dev/alpha', sessionPath: '/sessions/live.jsonl' })],
+    activeWorkspacePath: '/Users/dev/alpha',
+    ...base,
+  })
+  const [alpha] = groups
+  assert.deepEqual(alpha.threads.map((thread) => thread.sessionPath), [
+    '/sessions/live.jsonl',
+    '/sessions/newer.jsonl',
+    '/sessions/old.jsonl',
+  ])
+})
+
+test('excludes exited managed sessions from live threads', () => {
+  const groups = groupProjects({
+    recentSessions: [],
+    sessions: [live({ cwd: '/Users/dev/gamma', status: 'exited' })],
+    activeWorkspacePath: '/Users/dev/alpha',
+    ...base,
+  })
+  assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/alpha'])
+})

--- a/test/sidebar-projects.test.ts
+++ b/test/sidebar-projects.test.ts
@@ -23,7 +23,6 @@ const live = (over: Partial<SessionSummary>): SessionSummary => ({
 })
 
 const base = {
-  pinnedProjects: [] as string[],
   archivedProjects: [] as string[],
 }
 
@@ -56,16 +55,15 @@ test('always shows the active workspace even when it has no threads', () => {
   assert.equal(groups[0].threads.length, 0)
 })
 
-test('pinned projects lead and are marked, surviving refresh order', () => {
+test('a dragged project order leads, unordered projects follow default order', () => {
   const groups = groupProjects({
     recentSessions: [recent({ updatedAt: 10 })],
     sessions: [live({ cwd: '/Users/dev/beta' })],
     activeWorkspacePath: '/Users/dev/alpha',
-    pinnedProjects: ['/Users/dev/beta'],
+    projectOrder: ['/Users/dev/beta'],
     archivedProjects: [],
   })
-  assert.equal(groups[0].path, '/Users/dev/beta')
-  assert.equal(groups[0].pinned, true)
+  assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/beta', '/Users/dev/alpha'])
 })
 
 test('archived projects are hidden from the grouping', () => {
@@ -73,7 +71,6 @@ test('archived projects are hidden from the grouping', () => {
     recentSessions: [recent({})],
     sessions: [live({})],
     activeWorkspacePath: '/Users/dev/alpha',
-    pinnedProjects: [],
     archivedProjects: ['/Users/dev/beta'],
   })
   assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/alpha'])
@@ -97,6 +94,25 @@ test('orders threads with live sessions first, then by recency', () => {
   ])
 })
 
+test('pins and archives session rows independently from their project', () => {
+  const groups = groupProjects({
+    recentSessions: [
+      recent({ sessionPath: '/sessions/pinned.jsonl', updatedAt: 10 }),
+      recent({ sessionPath: '/sessions/archived.jsonl', updatedAt: 20 }),
+    ],
+    sessions: [],
+    activeWorkspacePath: '/Users/dev/alpha',
+    archivedProjects: [],
+    pinnedSessions: ['/sessions/pinned.jsonl'],
+    archivedSessions: ['/sessions/archived.jsonl'],
+  })
+  const alpha = groups.find((group) => group.path === '/Users/dev/alpha')
+  assert.equal(alpha?.threads[0]?.pinned, true)
+  assert.deepEqual(alpha?.archivedThreads.map((thread) => thread.key), [
+    '/sessions/archived.jsonl',
+  ])
+})
+
 test('excludes exited managed sessions from live threads', () => {
   const groups = groupProjects({
     recentSessions: [],
@@ -105,4 +121,24 @@ test('excludes exited managed sessions from live threads', () => {
     ...base,
   })
   assert.deepEqual(groups.map((group) => group.path), ['/Users/dev/alpha'])
+})
+
+test('carries session model metadata onto threads from history and live sessions', () => {
+  const groups = groupProjects({
+    recentSessions: [recent({ model: { provider: 'zai', id: 'glm-5.2' }, thinkingLevel: 'high' })],
+    sessions: [
+      live({
+        activeAgent: 'Glim (glmpi)',
+        model: { provider: 'zai', id: 'glm-5.2', name: 'GLM-5.2' },
+      }),
+    ],
+    activeWorkspacePath: '/Users/dev/alpha',
+    ...base,
+  })
+  const alpha = groups.find((group) => group.path === '/Users/dev/alpha')
+  const beta = groups.find((group) => group.path === '/Users/dev/beta')
+  assert.deepEqual(alpha?.threads[0]?.model, { provider: 'zai', id: 'glm-5.2' })
+  assert.equal(beta?.threads[0]?.worker, 'Glim (glmpi)')
+  assert.equal(beta?.threads[0]?.model?.name, 'GLM-5.2')
+  assert.equal(alpha?.threads[0]?.thinkingLevel, 'high')
 })

--- a/test/system-integration.test.ts
+++ b/test/system-integration.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
 import test from 'node:test'
 import {
+  chooseDirectory,
   externalWorkspacePath,
   getDesktopPlatform,
   getWslDistributionName,
@@ -13,6 +15,34 @@ test('detects Linux and WSL from the runtime environment', () => {
   assert.equal(getDesktopPlatform('linux', {}), 'linux')
   assert.equal(getDesktopPlatform('linux', { WSL_DISTRO_NAME: 'Ubuntu' }), 'wsl')
   assert.equal(getDesktopPlatform('win32', {}), 'windows')
+  assert.equal(getDesktopPlatform('darwin', {}), 'macos')
+})
+
+test('opens the macOS native folder chooser and returns its selected path', async () => {
+  let call: { command: string; args: string[] } | undefined
+  const selectedPath = await chooseDirectory(
+    '/Users/Ada/Projects',
+    'macos',
+    ((command: string, args: string[], options: Parameters<typeof spawn>[2]) => {
+      void options
+      call = { command, args }
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough
+        stderr: PassThrough
+      }
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      queueMicrotask(() => {
+        child.stdout.end('/Users/Ada/Projects/livecraft\n')
+        child.emit('exit', 0)
+      })
+      return child as never
+    }) as never,
+  )
+  assert.equal(selectedPath, '/Users/Ada/Projects/livecraft')
+  assert.equal(call?.command, 'osascript')
+  assert.equal(call?.args[0], '-e')
+  assert.match(call?.args[1] ?? '', /choose folder/)
 })
 
 test('reads the current WSL distribution name when available', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,14 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 const backendPort = process.env.PI_LIVECRAFT_BACKEND_PORT ?? '43121'
+const frontendPort = Number(process.env.PI_LIVECRAFT_FRONTEND_PORT ?? '43122')
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
+    port: frontendPort,
+    strictPort: true,
     proxy: {
       '/api': `http://127.0.0.1:${backendPort}`,
     },


### PR DESCRIPTION
## What changed

This publishes the project-scoped Livecraft session browser and the follow-up UI pass:

- project picker and folder-based project management
- project/session grouping with collapse and reorder support
- visible worker/model/reasoning metadata in session rows
- session pinning, archive, and hover actions wired to the session model
- Pi-free context titles and responsive/mobile layout adjustments

## Verification

- focused Livecraft tests: 16/16 passed
- TypeScript typecheck passed
- lint passed (existing baseline warnings only)
- format check passed
- production build passed
- `git diff --check` passed

## Scope

UI and supporting Livecraft session/project APIs only. No deployment or merge is included in this PR.
